### PR TITLE
Change the API of the mutated object response

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kubewarden-policy-sdk"
 description = "Kubewarden Policy SDK for the Rust language"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"
@@ -16,3 +16,6 @@ k8s-openapi = { version = "0.11.0", default-features = true, features = ["v1_20"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 wapc-guest = "0.4.0"
+
+[dev-dependencies]
+assert-json-diff = "2.0.1"

--- a/src/response.rs
+++ b/src/response.rs
@@ -10,6 +10,6 @@ pub struct ValidationResponse {
     pub message: Option<String>,
     /// Code shown to the user when the request is rejected
     pub code: Option<u16>,
-    /// Mutated Object serialized using JSON format - used only by mutation policies
-    pub mutated_object: Option<String>,
+    /// Mutated Object - used only by mutation policies
+    pub mutated_object: Option<serde_json::Value>,
 }


### PR DESCRIPTION
Change `mutated_object` attribute of the `ValidationResponse` to be a native JSON object instead of a string holding the a serialized JSON document.

Once this is merged I'll update the policy-evaluator crate to handle the new format