### PR TITLE
Protocol version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kubewarden-policy-sdk"
 description = "Kubewarden Policy SDK for the Rust language"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,10 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1.0"
 k8s-openapi = { version = "0.11.0", default-features = true, features = ["v1_20"] }
-serde = { version = "1.0", features = ["derive"] }
+num-derive = "0.3"
+num-traits = "0.2"
 serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 wapc-guest = "0.4.0"
 
 [dev-dependencies]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,0 +1,55 @@
+use num_derive::FromPrimitive;
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+
+/// ProtocolVersion describes the version of the communication protocol
+/// used to exchange information between the policy and the policy evaluator.
+///
+/// Policies built with this SDK provide the right value via the `protocol_version_guest`
+/// function.
+#[derive(Deserialize, Serialize, Debug, Clone, FromPrimitive, PartialEq)]
+pub enum ProtocolVersion {
+    /// This is an invalid version
+    #[serde(rename = "Unknown")]
+    Unknown = 0,
+    #[serde(rename = "v1")]
+    V1,
+}
+
+impl Default for ProtocolVersion {
+    fn default() -> Self {
+        Self::V1
+    }
+}
+
+impl TryFrom<Vec<u8>> for ProtocolVersion {
+    type Error = anyhow::Error;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        let version: ProtocolVersion = serde_json::from_slice(&value)
+            .map_err(|e| anyhow::anyhow!("Cannot convert value to ProtocolVersion: {:?}", e))?;
+        Ok(version)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_from_known_version() -> Result<(), ()> {
+        let version = ProtocolVersion::try_from(b"\"v1\"".to_vec());
+        assert!(version.is_ok());
+        assert_eq!(version.unwrap(), ProtocolVersion::V1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn try_from_unknown_version() -> Result<(), ()> {
+        let version = ProtocolVersion::try_from(b"\"v100\"".to_vec());
+        assert!(version.is_err());
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR introduces the concept of "protocol version". This is a versioning scheme for policies, that describes the communication protocol used by the policy to communicate with the policy evaluator.

Needed to fix https://github.com/kubewarden/policy-sdk-rust/issues/11