### PR TITLE
Implement display for protocol version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1.0"
 k8s-openapi = { version = "0.11.0", default-features = true, features = ["v1_20"] }
+num = "0.4"
 num-derive = "0.3"
 num-traits = "0.2"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kubewarden-policy-sdk"
 description = "Kubewarden Policy SDK for the Rust language"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"


### PR DESCRIPTION
Implement the Display trait for `ProtocolVersion`. This simplifies the printing of protocol version inside of kwctl

Once this is merged, I'll release a new version of this crate.
