### PR TITLE
Sigstore container verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0"
-k8s-openapi = { version = "0.14.0", default-features = true, features = ["v1_20"] }
+k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_22"] }
 num = "0.4"
 num-derive = "0.3"
 num-traits = "0.2"
@@ -23,3 +23,4 @@ wapc-guest = "0.4.0"
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"
+serde_yaml = "0.8.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 slog = "2.7.0"
 wapc-guest = "0.4.0"
+serde_yaml = "0.8.23"
+url = { version = "2.2.2", features = ["serde"] }
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"
-serde_yaml = "0.8.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,5 @@ url = { version = "2.2.2", features = ["serde"] }
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"
+serial_test = "0.6.0"
+mockall = "0.11.0"

--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -1,5 +1,5 @@
-use crate::host_capabilities::verification::LatestVerificationConfig;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 pub mod verification;
 
@@ -16,10 +16,11 @@ pub enum CallbackRequestType {
     /// Require the verification of the manifest digest of an OCI object (be
     /// it an image or anything else that can be stored into an OCI registry)
     /// to be signed by Sigstore
-    SigstoreVerify {
+    SigstorePubKeyVerify {
         /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,
         /// The configuration to use at verification time
-        config: LatestVerificationConfig,
+        pub_keys: Vec<String>,
+        annotations: HashMap<String, String>,
     },
 }

--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -1,3 +1,4 @@
+use crate::host_capabilities::verification::KeylessInfo;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -21,6 +22,13 @@ pub enum CallbackRequestType {
         image: String,
         /// The configuration to use at verification time
         pub_keys: Vec<String>,
-        annotations: HashMap<String, String>,
+        annotations: Option<HashMap<String, String>>,
+    },
+    SigstoreKeylessVerify {
+        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
+        image: String,
+        /// The configuration to use at verification time
+        keyless: Vec<KeylessInfo>,
+        annotations: Option<HashMap<String, String>>,
     },
 }

--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -1,3 +1,4 @@
+use crate::host_capabilities::verification::LatestVerificationConfig;
 use serde::{Deserialize, Serialize};
 
 pub mod verification;
@@ -19,6 +20,6 @@ pub enum CallbackRequestType {
         /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,
         /// The configuration to use at verification time
-        config: verification::Config,
+        config: LatestVerificationConfig,
     },
 }

--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -20,15 +20,17 @@ pub enum CallbackRequestType {
     SigstorePubKeyVerify {
         /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,
-        /// The configuration to use at verification time
+        /// List of PEM encoded keys that must have been used to sign the OCI object
         pub_keys: Vec<String>,
+        /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
         annotations: Option<HashMap<String, String>>,
     },
     SigstoreKeylessVerify {
         /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,
-        /// The configuration to use at verification time
+        /// List of keyless signatures that must be found
         keyless: Vec<KeylessInfo>,
+        /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
         annotations: Option<HashMap<String, String>>,
     },
 }

--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+
+pub mod verification;
+
+/// Describes the different kinds of request a waPC guest can make to
+/// our host.
+#[derive(Serialize, Deserialize, Debug)]
+pub enum CallbackRequestType {
+    /// Require the computation of the manifest digest of an OCI object (be
+    /// it an image or anything else that can be stored into an OCI registry)
+    OciManifestDigest {
+        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
+        image: String,
+    },
+    /// Require the verification of the manifest digest of an OCI object (be
+    /// it an image or anything else that can be stored into an OCI registry)
+    /// to be signed by Sigstore
+    SigstoreVerify {
+        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
+        image: String,
+        /// The configuration to use at verification time
+        config: verification::Config,
+    },
+}

--- a/src/host_capabilities/verification.rs
+++ b/src/host_capabilities/verification.rs
@@ -1,25 +1,40 @@
 use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::host_capabilities::CallbackRequestType;
 
 type WapcVerifyFN = fn(&[u8]) -> Result<Vec<u8>>;
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct KeylessInfo {
+    pub issuer: String,
+    pub subject: String,
+}
+
 pub fn verify_pub_keys_image(
     image: &str,
     pub_keys: Vec<String>,
-    annotations: HashMap<String, String>,
+    annotations: Option<HashMap<String, String>>,
 ) -> Result<bool> {
-    wapc_invoke_verify_pub_keys_image(image, pub_keys, annotations, wapc_invoke_verify)
+    invoke_verify_pub_keys_image(image, pub_keys, annotations, wapc_invoke_verify)
+}
+
+pub fn verify_keyless_exact_match(
+    image: &str,
+    keyless: Vec<KeylessInfo>,
+    annotations: Option<HashMap<String, String>>,
+) -> Result<bool> {
+    invoke_verify_keyless_exact_match(image, keyless, annotations, wapc_invoke_verify)
 }
 
 // This function is needed to have an easier way to test the verification outcomes when doing
 // testing. Tests do NOT run inside of a Wasm environment, hence we can't call the actual waPC
 // functions.
-fn wapc_invoke_verify_pub_keys_image(
+fn invoke_verify_pub_keys_image(
     image: &str,
     pub_keys: Vec<String>,
-    annotations: HashMap<String, String>,
+    annotations: Option<HashMap<String, String>>,
     wapc_verify_fn: WapcVerifyFN,
 ) -> Result<bool> {
     let req = CallbackRequestType::SigstorePubKeyVerify {
@@ -41,8 +56,38 @@ fn wapc_invoke_verify_pub_keys_image(
     Ok(verified)
 }
 
+// This function is needed to have an easier way to test the verification outcomes when doing
+// testing. Tests do NOT run inside of a Wasm environment, hence we can't call the actual waPC
+// functions.
+fn invoke_verify_keyless_exact_match(
+    image: &str,
+    keyless: Vec<KeylessInfo>,
+    annotations: Option<HashMap<String, String>>,
+    wapc_verify_fn: WapcVerifyFN,
+) -> Result<bool> {
+    let req = CallbackRequestType::SigstoreKeylessVerify {
+        image: image.to_string(),
+        keyless,
+        annotations,
+    };
+
+    let msg = serde_json::to_vec(&req)
+        .map_err(|e| anyhow!("error serializing the validation request: {}", e))?;
+
+    let response_raw = wapc_verify_fn(&msg)?;
+
+    //TODO this must be a json
+    let verified = *response_raw
+        .first()
+        .ok_or_else(|| anyhow!("error parsing the callback response"))?
+        != 0;
+    Ok(verified)
+}
+
 fn wapc_invoke_verify(payload: &[u8]) -> Result<Vec<u8>> {
-    let response_raw = wapc_guest::host_call("kubewarden", "oci", "v1/verify/pubkeys", payload)
-        .map_err(|e| anyhow::anyhow!("erorr invoking wapc logging facility: {:?}", e))?;
+    let response_raw = wapc_guest::host_call("kubewarden", "oci", "v1/verify", payload)
+        .map_err(|e| anyhow::anyhow!("error invoking wapc verify: {:?}", e))?;
     Ok(response_raw)
 }
+
+//TODO tests?

--- a/src/host_capabilities/verification.rs
+++ b/src/host_capabilities/verification.rs
@@ -1,0 +1,166 @@
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use crate::host_capabilities::CallbackRequestType;
+
+/// TODO: write docs
+pub fn verify_image(image: &str, config: Config) -> Result<bool> {
+    let req = CallbackRequestType::SigstoreVerify {
+        image: image.to_string(),
+        config,
+    };
+
+    let msg = serde_json::to_vec(&req)
+        .map_err(|e| anyhow!("error serializing the validation request: {}", e))?;
+
+    let response_raw = wapc_invoke_verify(&msg)?;
+
+    let verified: bool = serde_json::from_slice(&response_raw)
+        .map_err(|e| anyhow!("Cannot decode verification response: {}", e))?;
+    Ok(verified)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn wapc_invoke_verify(payload: &[u8]) -> Result<Vec<u8>> {
+    let response_raw = wapc_guest::host_call("kubewarden", "oci", "verify", &msg)
+        .map_err(|e| anyhow::anyhow!("erorr invoking wapc logging facility: {:?}", e))?;
+    response_raw.into()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn wapc_invoke_verify(_payload: &[u8]) -> Result<Vec<u8>> {
+    //TODO find a way to allow users to provide different results
+    //a global maybe?
+    Ok(br#"true"#.to_vec())
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Request {
+    pub image: String,
+    pub config: Config,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConfigV1 {
+    pub all_of: Option<Vec<Signature>>,
+    pub any_of: Option<AnyOf>,
+}
+
+/// Enum that holds all the known versions of the configuration file
+///
+/// An unsupported version is a object that has `apiVersion` with an
+/// unknown value (e.g: 1000)
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "apiVersion", rename_all = "camelCase", deny_unknown_fields)]
+pub enum VersionedConfig {
+    #[serde(rename = "v1")]
+    V1(ConfigV1),
+    #[serde(other)]
+    Unsupported,
+}
+
+/// Enum that distinguish between a well formed (but maybe unknown) version of
+/// the verification config, and something which is "just wrong".
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Config {
+    Versioned(VersionedConfig),
+    Invalid(),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AnyOf {
+    #[serde(default = "default_minimum_matches")]
+    pub minimum_matches: u8,
+    pub signatures: Vec<Signature>,
+}
+
+fn default_minimum_matches() -> u8 {
+    1
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", tag = "kind", deny_unknown_fields)]
+pub enum Signature {
+    PubKey {
+        owner: Option<String>,
+        key: String,
+        annotations: Option<HashMap<String, String>>,
+    },
+    GenericIssuer {
+        issuer: String,
+        subject: Subject,
+        annotations: Option<HashMap<String, String>>,
+    },
+    GithubAction {
+        owner: String,
+        repo: Option<String>,
+        annotations: Option<HashMap<String, String>>,
+    },
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub enum Subject {
+    Equal(String),
+    UrlPrefix(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    //TODO: write tests
+
+    // In this case, the settings of the policy defined by the user is going
+    // to embed the configuration object:
+    //
+    // ```yaml
+    // somethingUnrelated: hello world
+    // verificationConfig:
+    //   apiVersion: v1
+    //   allOf:
+    //     - kind: genericIssuer
+    //       issuer: https://token.actions.githubusercontent.com
+    //       subject:
+    //          urlPrefix: https://github.com/kubewarden # should deserialize path to kubewarden/
+    //     - kind: genericIssuer
+    //       issuer: https://yourdomain.com/oauth2
+    //       subject:
+    //          urlPrefix: https://github.com/kubewarden/ # should deserialize path to kubewarden/
+    //
+    // ```
+    #[derive(Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    struct SettingsExample {
+        something_unrelated: String,
+        verification_config: Config,
+    }
+
+    // In this case, the settings of the policy defined by the user is going
+    // to use some primites of the SDK Verification::Config
+    //
+    // ```yaml
+    // somethingUnrelated: hello world
+    // verificationConfig:
+    //   allOf:
+    //     - kind: genericIssuer
+    //       issuer: https://token.actions.githubusercontent.com
+    //       subject:
+    //          urlPrefix: https://github.com/kubewarden # should deserialize path to kubewarden/
+    //     - kind: genericIssuer
+    //       issuer: https://yourdomain.com/oauth2
+    //       subject:
+    //          urlPrefix: https://github.com/kubewarden/ # should deserialize path to kubewarden/
+    //
+    // ```
+    #[derive(Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    struct SettingsCustomExample {
+        something_unrelated: String,
+        verification_config: ConfigV1,
+    }
+}

--- a/src/host_capabilities/verification.rs
+++ b/src/host_capabilities/verification.rs
@@ -6,18 +6,29 @@ use tests::mock_wapc as wapc_guest;
 
 use crate::host_capabilities::CallbackRequestType;
 
+/// VerificationResponse holds the response of a sigstore signatures verification
 #[derive(Serialize, Deserialize, Clone)]
 pub struct VerificationResponse {
+    /// true if the image is trusted, which means verification was successfull
     pub is_trusted: bool,
+    /// digest of the image that was verified
     pub digest: String,
 }
 
+/// KeylessInfo holds information about a keyless signature
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct KeylessInfo {
+    /// the issuer identifier
     pub issuer: String,
+    /// contains the information of the user used to authenticate against the OIDC provider
     pub subject: String,
 }
 
+/// verify sigstore signatures of an image using public keys
+/// # Arguments
+/// * `image` -  image to be verified
+/// * `pub_keys`  -  list of PEM encoded keys that must have been used to sign the OCI object
+/// * `annotations` - annotations that must have been provided by all signers when they signed the OCI artifact
 pub fn verify_pub_keys_image(
     image: &str,
     pub_keys: Vec<String>,
@@ -32,6 +43,11 @@ pub fn verify_pub_keys_image(
     verify(req)
 }
 
+/// verify sigstore signatures of an image using keyless
+/// # Arguments
+/// * `image` -  image to be verified
+/// * `keyless`  -  list of issuers and subjects
+/// * `annotations` - annotations that must have been provided by all signers when they signed the OCI artifact
 pub fn verify_keyless_exact_match(
     image: &str,
     keyless: Vec<KeylessInfo>,

--- a/src/host_capabilities/verification.rs
+++ b/src/host_capabilities/verification.rs
@@ -1,27 +1,31 @@
 use anyhow::{anyhow, Result};
-use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
-use url::Url;
 
 use crate::host_capabilities::CallbackRequestType;
 
 type WapcVerifyFN = fn(&[u8]) -> Result<Vec<u8>>;
 
-pub fn verify_image(image: &str, config: LatestVerificationConfig) -> Result<bool> {
-    wapc_invoke_verify_image(image, config, wapc_invoke_verify)
+pub fn verify_pub_keys_image(
+    image: &str,
+    pub_keys: Vec<String>,
+    annotations: HashMap<String, String>,
+) -> Result<bool> {
+    wapc_invoke_verify_pub_keys_image(image, pub_keys, annotations, wapc_invoke_verify)
 }
 
 // This function is needed to have an easier way to test the verification outcomes when doing
 // testing. Tests do NOT run inside of a Wasm environment, hence we can't call the actual waPC
 // functions.
-fn wapc_invoke_verify_image(
+fn wapc_invoke_verify_pub_keys_image(
     image: &str,
-    config: LatestVerificationConfig,
+    pub_keys: Vec<String>,
+    annotations: HashMap<String, String>,
     wapc_verify_fn: WapcVerifyFN,
 ) -> Result<bool> {
-    let req = CallbackRequestType::SigstoreVerify {
+    let req = CallbackRequestType::SigstorePubKeyVerify {
         image: image.to_string(),
-        config,
+        pub_keys,
+        annotations,
     };
 
     let msg = serde_json::to_vec(&req)
@@ -29,6 +33,7 @@ fn wapc_invoke_verify_image(
 
     let response_raw = wapc_verify_fn(&msg)?;
 
+    //TODO this must be a json
     let verified = *response_raw
         .first()
         .ok_or_else(|| anyhow!("error parsing the callback response"))?
@@ -37,140 +42,7 @@ fn wapc_invoke_verify_image(
 }
 
 fn wapc_invoke_verify(payload: &[u8]) -> Result<Vec<u8>> {
-    let response_raw = wapc_guest::host_call("kubewarden", "oci", "verify", payload)
+    let response_raw = wapc_guest::host_call("kubewarden", "oci", "v1/verify/pubkeys", payload)
         .map_err(|e| anyhow::anyhow!("erorr invoking wapc logging facility: {:?}", e))?;
     Ok(response_raw)
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Request {
-    pub image: String,
-    pub config: VerificationConfigV1,
-}
-
-fn default_minimum_matches() -> u8 {
-    1
-}
-
-/// Alias to the type that is currently used to store the
-/// verification settings.
-///
-/// When a new version is created:
-/// * Update this stype to point to the new version
-/// * Implement `TryFrom` that goes from (v - 1) to (v)
-pub type LatestVerificationConfig = VerificationConfigV1;
-
-#[derive(Serialize, Default, Deserialize, Debug, Clone, PartialEq, Eq)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VerificationConfigV1 {
-    pub all_of: Option<Vec<Signature>>,
-    pub any_of: Option<AnyOf>,
-}
-
-/// Enum that holds all the known versions of the configuration file
-///
-/// An unsupported version is a object that has `apiVersion` with an
-/// unknown value (e.g: 1000)
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-#[serde(tag = "apiVersion", rename_all = "camelCase", deny_unknown_fields)]
-pub enum VersionedVerificationConfig {
-    #[serde(rename = "v1")]
-    V1(VerificationConfigV1),
-    #[serde(other)]
-    Unsupported,
-}
-
-/// Enum that distinguish between a well formed (but maybe unknown) version of
-/// the verification config, and something which is "just wrong".
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum VerificationConfig {
-    Versioned(VersionedVerificationConfig),
-    Invalid(serde_yaml::Value),
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct AnyOf {
-    #[serde(default = "default_minimum_matches")]
-    pub minimum_matches: u8,
-    pub signatures: Vec<Signature>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-#[serde(rename_all = "camelCase", tag = "kind", deny_unknown_fields)]
-pub enum Signature {
-    PubKey {
-        owner: Option<String>,
-        key: String,
-        annotations: Option<HashMap<String, String>>,
-    },
-    GenericIssuer {
-        issuer: String,
-        subject: Subject,
-        annotations: Option<HashMap<String, String>>,
-    },
-    GithubAction {
-        owner: String,
-        repo: Option<String>,
-        annotations: Option<HashMap<String, String>>,
-    },
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub enum Subject {
-    Equal(String),
-    #[serde(deserialize_with = "deserialize_subject_url_prefix")]
-    UrlPrefix(Url),
-}
-
-fn deserialize_subject_url_prefix<'de, D>(deserializer: D) -> Result<Url, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let mut url = Url::deserialize(deserializer)?;
-    if !url.path().ends_with('/') {
-        // sanitize url prefix path by postfixing `/`, to prevent
-        // `https://github.com/kubewarden` matching
-        // `https://github.com/kubewarden-malicious/`
-        url.set_path(format!("{}{}", url.path(), '/').as_str());
-    }
-    Ok(url)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn wapc_invoke_verify_ok(_payload: &[u8]) -> Result<Vec<u8>> {
-        let is_trusted_byte: u8 = true.into();
-        let is_trusted_vec_byte = vec![is_trusted_byte];
-
-        Ok(is_trusted_vec_byte)
-    }
-
-    fn wapc_invoke_verify_err(_payload: &[u8]) -> Result<Vec<u8>> {
-        Err(anyhow!("error"))
-    }
-
-    #[test]
-    fn test_wapc_invoke_verify_ok() {
-        let config = VerificationConfigV1 {
-            all_of: None,
-            any_of: None,
-        };
-        let result = wapc_invoke_verify_image("test", config, wapc_invoke_verify_ok);
-        assert_eq!(result.unwrap(), true);
-    }
-
-    #[test]
-    fn test_wapc_invoke_verify_err() {
-        let config = VerificationConfigV1 {
-            all_of: None,
-            any_of: None,
-        };
-        let result = wapc_invoke_verify_image("test", config, wapc_invoke_verify_err);
-        assert_eq!(result.is_err(), true);
-    }
 }

--- a/src/host_capabilities/verification.rs
+++ b/src/host_capabilities/verification.rs
@@ -11,6 +11,9 @@ pub fn verify_image(image: &str, config: LatestVerificationConfig) -> Result<boo
     wapc_invoke_verify_image(image, config, wapc_invoke_verify)
 }
 
+// This function is needed to have an easier way to test the verification outcomes when doing
+// testing. Tests do NOT run inside of a Wasm environment, hence we can't call the actual waPC
+// functions.
 fn wapc_invoke_verify_image(
     image: &str,
     config: LatestVerificationConfig,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ extern crate k8s_openapi;
 use anyhow::anyhow;
 
 pub mod cluster_context;
+pub mod host_capabilities;
 pub mod logging;
 pub mod metadata;
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
Add two new methods that can be called from the policies: `verify_pub_keys_image()` and  `verify_keyless_exact_match() ` They will return a `VerificationResponse` which contains a boolean indicating if it is trusted and the digest.

Fix https://github.com/kubewarden/policy-server/issues/99
Superseeds https://github.com/kubewarden/policy-sdk-rust/pull/32