### PR TITLE
Automate the release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: kwctl release
+on:
+  push:
+    tags:
+    - 'v*'
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+
+  ci:
+    # A branch is required, and cannot be dynamic - https://github.com/actions/runner/issues/1493
+    uses: kubewarden/policy-sdk-rust/.github/workflows/tests.yml@main
+
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    needs:
+      - ci
+    steps:
+    - name: Create Release
+      id: create-release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Kubewarden Rust SDK ${{ github.ref }}
+        draft: false
+        prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
+
+  publish:
+    name: Publish on crates.io
+    runs-on: ubuntu-latest
+    needs:
+      - ci
+    steps:
+      -  uses: actions/checkout@v2
+      -  uses: actions-rs/toolchain@v1
+         with:
+           toolchain: stable
+           override: true
+
+      - name: publish crates
+        run: cargo publish --token ${{ secrets.CARGO_API_TOKEN }}


### PR DESCRIPTION
Every time a new tag named `v*` is created:

* Create a GitHub Release
* Publish the crate on crates.io

The crate is going to be published using a token issued to the chimera bot
