### PR TITLE
Fix k8s-openapi dependency to break building of rust policies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,34 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0"
-k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_22"] }
+# Starting from k8s-openapi v0.14, it is NOT recommended to be explicit about
+# the kubernetes features to be used when building a library. That's because
+# the final version of the k8s API to be supported must be made by the consumer
+# of the library.
+#
+# Otherwise it's possible to end up in situations like:
+# * kubewarden-policy-sdk enables the `v1_22` feature of k8s-openapi
+# * `consumer-foo` requires k8s-openapi too but enables the `v1_23` feature
+# A build error is then raised by cargo because the same version must be picked
+# by all the crates making use of k8s-openapi.
+#
+# Because of that, no feature is chosen inside of the `dependencies` section.
+# This however can lead to issues when executing commands like
+# cargo `build|check|doc`. That's because the `k8s-openapi` is specified again
+# inside of the `dev-dependencies`, this time with a k8s feature enabled
+k8s-openapi = { version = "0.14.0", default-features = false }
 num = "0.4"
 num-derive = "0.3"
 num-traits = "0.2"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-slog = "2.7.0"
-wapc-guest = "0.4.0"
 serde_yaml = "0.8.23"
+slog = "2.7.0"
 url = { version = "2.2.2", features = ["serde"] }
+wapc-guest = "0.4.0"
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"
-serial_test = "0.6.0"
 mockall = "0.11.0"
+serial_test = "0.6.0"
+k8s-openapi = { version = "0.14.0", default-features = false, features = [ "v1_23" ]}


### PR DESCRIPTION
Starting from k8s-openapi v0.14, it is NOT recommended to be explicit about the kubernetes features to be used when building a library. That's because the final version of the k8s API to be supported must be made by the consumer of the library.

Otherwise it's possible to end up in situations like:
* kubewarden-policy-sdk enables the `v1_22` feature of k8s-openapi
* `consumer-foo` requires k8s-openapi too but enables the `v1_23` feature A build error is then raised by cargo because the same version must be picked by all the crates making use of k8s-openapi.

Because of that, no feature is chosen inside of the `dependencies` section. This however can lead to issues when executing commands like cargo `build|check|doc`. That's because the `k8s-openapi` is specified again inside of the `dev-dependencies`, this time with a k8s feature enabled.

This is required to fix issues like this one: https://github.com/kubewarden/readonly-root-filesystem-psp-policy/runs/6251507509?check_suite_focus=true

