### PR TITLE
remove debug of trait error when invoking wapc verify

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kubewarden-policy-sdk"
 description = "Kubewarden Policy SDK for the Rust language"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"

--- a/src/host_capabilities/verification.rs
+++ b/src/host_capabilities/verification.rs
@@ -66,7 +66,7 @@ fn verify(req: CallbackRequestType) -> Result<VerificationResponse> {
     let msg = serde_json::to_vec(&req)
         .map_err(|e| anyhow!("error serializing the validation request: {}", e))?;
     let response_raw = wapc_guest::host_call("kubewarden", "oci", "v1/verify", &msg)
-        .map_err(|e| anyhow::anyhow!("error invoking wapc verify: {:?}", e))?;
+        .map_err(|e| anyhow!("{}", e))?;
 
     let response: VerificationResponse = serde_json::from_slice(&response_raw)?;
 


### PR DESCRIPTION
Message returned with this chage is:

```
Pod nginx is not accepted: verification of image ghcr.io/kubewarden/test-verify-image-signatures:unsigned failed: Host error: Callback evaluation failure: no signatures found for image: ghcr.io/kubewarden/test-verify-image-signatures:unsigned 
```

Fix https://github.com/kubewarden/policy-fetcher/issues/85

