### PR TITLE
Release v0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kubewarden-policy-sdk"
 description = "Kubewarden Policy SDK for the Rust language"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.5.0"
+version = "0.5.1"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"
@@ -27,7 +27,7 @@ anyhow = "1.0"
 # This however can lead to issues when executing commands like
 # cargo `build|check|doc`. That's because the `k8s-openapi` is specified again
 # inside of the `dev-dependencies`, this time with a k8s feature enabled
-k8s-openapi = { version = "0.14.0", default-features = false }
+k8s-openapi = { version = "0.15.0", default-features = false }
 num = "0.4"
 num-derive = "0.3"
 num-traits = "0.2"
@@ -36,10 +36,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8.24"
 slog = "2.7.0"
 url = { version = "2.2.2", features = ["serde"] }
-wapc-guest = "0.4.0"
+wapc-guest = "1.0.0"
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"
 mockall = "0.11.0"
 serial_test = "0.6.0"
-k8s-openapi = { version = "0.14.0", default-features = false, features = [ "v1_23" ]}
+k8s-openapi = { version = "0.15.0", default-features = false, features = [ "v1_24" ]}


### PR DESCRIPTION
We need to update the k8s-openapi dependency there, in order to update it at higher levels.

I also updated the wapc-guest code, the project bumped from v0.4.0 -> v1.0.0 without breaking changes.
