### PR TITLE
refactorings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kubewarden-policy-sdk"
 description = "Kubewarden Policy SDK for the Rust language"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.5.1"
+version = "0.6.0"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ authors = [
 edition = "2018"
 license = "Apache-2.0"
 
+[features]
+default = [ "cluster-context" ]
+cluster-context = [ "dep:k8s-openapi" ]
+
 [dependencies]
 anyhow = "1.0"
 # Starting from k8s-openapi v0.14, it is NOT recommended to be explicit about
@@ -27,7 +31,7 @@ anyhow = "1.0"
 # This however can lead to issues when executing commands like
 # cargo `build|check|doc`. That's because the `k8s-openapi` is specified again
 # inside of the `dev-dependencies`, this time with a k8s feature enabled
-k8s-openapi = { version = "0.15.0", default-features = false }
+k8s-openapi = { version = "0.15.0", default-features = false, optional = true }
 num = "0.4"
 num-derive = "0.3"
 num-traits = "0.2"
@@ -42,4 +46,4 @@ wapc-guest = "1.0.0"
 assert-json-diff = "2.0.1"
 mockall = "0.11.1"
 serial_test = "0.7.0"
-k8s-openapi = { version = "0.15.0", default-features = false, features = [ "v1_24" ]}
+k8s-openapi = { version = "0.15.0", default-features = false, features = [ "v1_24" ] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
-extern crate k8s_openapi;
 
 use anyhow::anyhow;
 
+#[cfg(feature = "cluster-context")]
 pub mod cluster_context;
 pub mod host_capabilities;
 pub mod logging;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@ use anyhow::anyhow;
 
 #[cfg(feature = "cluster-context")]
 pub mod cluster_context;
+
+pub use wapc_guest;
+
 pub mod host_capabilities;
 pub mod logging;
 pub mod metadata;

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// A ValidationResponse object holds the outcome of policy
 /// evaluation.
@@ -12,4 +13,14 @@ pub struct ValidationResponse {
     pub code: Option<u16>,
     /// Mutated Object - used only by mutation policies
     pub mutated_object: Option<serde_json::Value>,
+    /// AuditAnnotations is an unstructured key value map set by remote admission controller (e.g. error=image-blacklisted).
+    /// MutatingAdmissionWebhook and ValidatingAdmissionWebhook admission controller will prefix the keys with
+    /// admission webhook name (e.g. imagepolicy.example.com/error=image-blacklisted). AuditAnnotations will be provided by
+    /// the admission webhook to add additional context to the audit log for this request.
+    pub audit_annotations: Option<HashMap<String, String>>,
+    /// warnings is a list of warning messages to return to the requesting API client.
+    /// Warning messages describe a problem the client making the API request should correct or be aware of.
+    /// Limit warnings to 120 characters if possible.
+    /// Warnings over 256 characters and large numbers of warnings may be truncated.
+    pub warnings: Option<Vec<String>>,
 }


### PR DESCRIPTION
- feat!: make k8s-openapi dependency optional
- feat: export wapc-guest
- feat!: validation response - offer all k8s fields
- Tag v0.6.0
