### PR TITLE
feat: Add callbacks for verification of GHA signatures, Url Prefix

### DIFF
--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -36,6 +36,15 @@ pub enum CallbackRequestType {
         annotations: Option<HashMap<String, String>>,
     },
 
+    SigstoreKeylessPrefixVerify {
+        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
+        image: String,
+        /// List of keyless signatures that must be found
+        keyless: Vec<KeylessInfo>,
+        /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
+        annotations: Option<HashMap<String, String>>,
+    },
+
     SigstoreGithubActionsVerify {
         /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,

--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -41,7 +41,7 @@ pub enum CallbackRequestType {
         image: String,
         /// owner of the repository. E.g: octocat
         owner: String,
-        /// Optonal - Repo of the GH Action workflow that signed the artifact. E.g: example-repo
+        /// Optional - Repo of the GH Action workflow that signed the artifact. E.g: example-repo
         repo: Option<String>,
         /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
         annotations: Option<HashMap<String, String>>,

--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -35,6 +35,18 @@ pub enum CallbackRequestType {
         /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
         annotations: Option<HashMap<String, String>>,
     },
+
+    SigstoreGithubActionsVerify {
+        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
+        image: String,
+        /// owner of the repository. E.g: octocat
+        owner: String,
+        /// Optonal - Repo of the GH Action workflow that signed the artifact. E.g: example-repo
+        repo: Option<String>,
+        /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
+        annotations: Option<HashMap<String, String>>,
+    },
+
     /// Lookup the addresses for a given hostname via DNS
     DNSLookupHost { host: String },
 }

--- a/src/host_capabilities/verification.rs
+++ b/src/host_capabilities/verification.rs
@@ -62,6 +62,29 @@ pub fn verify_keyless_exact_match(
     verify(req)
 }
 
+/// verify sigstore signatures of an image using keyless signatures made via
+/// Github Actions.
+/// # Arguments
+/// * `image` -  image to be verified
+/// * `owner` - owner of the repository. E.g: octocat
+/// * `repo` - Optional. repo of the GH Action workflow that signed the artifact. E.g: example-repo. Optional.
+/// * `annotations` - annotations that must have been provided by all signers when they signed the OCI artifact
+pub fn verify_keyless_github_actions(
+    image: &str,
+    owner: String,
+    repo: Option<String>,
+    annotations: Option<HashMap<String, String>>,
+) -> Result<VerificationResponse> {
+    let req = CallbackRequestType::SigstoreGithubActionsVerify {
+        image: image.to_string(),
+        owner,
+        repo,
+        annotations,
+    };
+
+    verify(req)
+}
+
 fn verify(req: CallbackRequestType) -> Result<VerificationResponse> {
     let msg = serde_json::to_vec(&req)
         .map_err(|e| anyhow!("error serializing the validation request: {}", e))?;

--- a/src/host_capabilities/verification.rs
+++ b/src/host_capabilities/verification.rs
@@ -62,6 +62,28 @@ pub fn verify_keyless_exact_match(
     verify(req)
 }
 
+/// verify sigstore signatures of an image using keyless. Here, the provided
+/// subject string is streated as a URL prefix, and sanitized to a valid URL on
+/// itself by appending `\` to prevent typosquatting. Then, the provided subject
+/// will satisfy the signature only if it is a prefix of the signature subject.
+/// # Arguments
+/// * `image` -  image to be verified
+/// * `keyless`  -  list of issuers and subjects
+/// * `annotations` - annotations that must have been provided by all signers when they signed the OCI artifact
+pub fn verify_keyless_prefix_match(
+    image: &str,
+    keyless: Vec<KeylessInfo>,
+    annotations: Option<HashMap<String, String>>,
+) -> Result<VerificationResponse> {
+    let req = CallbackRequestType::SigstoreKeylessPrefixVerify {
+        image: image.to_string(),
+        keyless,
+        annotations,
+    };
+
+    verify(req)
+}
+
 /// verify sigstore signatures of an image using keyless signatures made via
 /// Github Actions.
 /// # Arguments

--- a/src/host_capabilities/verification.rs
+++ b/src/host_capabilities/verification.rs
@@ -187,4 +187,35 @@ mod tests {
 
         assert!(res.is_err())
     }
+
+
+    #[serial]
+    #[test]
+    fn verify_keyless_github_actions_trusted() {
+        let ctx = mock_wapc::host_call_context();
+        ctx.expect().times(1).returning(|_, _, _, _| {
+            Ok(serde_json::to_vec(&{
+                VerificationResponse {
+                    is_trusted: true,
+                    digest: "digest".to_string(),
+                }
+            })
+            .unwrap())
+        });
+        let res = verify_keyless_github_actions("image", "owner".to_string(), None, None);
+
+        assert_eq!(res.unwrap().is_trusted, true)
+    }
+
+    #[serial]
+    #[test]
+    fn verify_keyless_github_actions_not_trusted() {
+        let ctx = mock_wapc::host_call_context();
+        ctx.expect()
+            .times(1)
+            .returning(|_, _, _, _| Err(Box::new(core::fmt::Error {})));
+        let res = verify_keyless_github_actions("image", "owner".to_string(), None, None);
+
+        assert!(res.is_err())
+    }
 }

--- a/src/host_capabilities/verification.rs
+++ b/src/host_capabilities/verification.rs
@@ -210,6 +210,49 @@ mod tests {
         assert!(res.is_err())
     }
 
+    #[serial]
+    #[test]
+    fn verify_keyless_prefix_trusted() {
+        let ctx = mock_wapc::host_call_context();
+        ctx.expect().times(1).returning(|_, _, _, _| {
+            Ok(serde_json::to_vec(&{
+                VerificationResponse {
+                    is_trusted: true,
+                    digest: "digest".to_string(),
+                }
+            })
+            .unwrap())
+        });
+        let res = verify_keyless_prefix_match(
+            "image",
+            vec![KeylessInfo {
+                subject: "subject".to_string(),
+                issuer: "issuer".to_string(),
+            }],
+            None,
+        );
+
+        assert_eq!(res.unwrap().is_trusted, true)
+    }
+
+    #[serial]
+    #[test]
+    fn verify_keyless_prefix_not_trusted() {
+        let ctx = mock_wapc::host_call_context();
+        ctx.expect()
+            .times(1)
+            .returning(|_, _, _, _| Err(Box::new(core::fmt::Error {})));
+        let res = verify_keyless_prefix_match(
+            "image",
+            vec![KeylessInfo {
+                subject: "subject".to_string(),
+                issuer: "issuer".to_string(),
+            }],
+            None,
+        );
+
+        assert!(res.is_err())
+    }
 
     #[serial]
     #[test]


### PR DESCRIPTION
## Description

Add new API:
  `pub CallbackRequestType::SigstoreGithubActionsVerify{}`
  `pub fn verify_keyless_github_actions()`
  `pub CallbackRequestType::SigstoreKeylessPrefixVerify{}`
  `pub fn verify_keyless_prefix_match()`

Consumers of the SDK can levarage this new API call to ask for
verification of signatures done with jobs in Github Actions, and to ask for
verification of signatures where the subject needs to be a URL prefix of
the signature subject, respectively.

This API addition is leveraged by policy-evaluator to perform the
callbacks in the wasm host.


<!-- Please provide the link to the GitHub issue you are addressing -->
Needed by https://github.com/kubewarden/policy-sdk-rust/issues/41
Needed by https://github.com/kubewarden/policy-sdk-rust/issues/40

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
