### PR TITLE
Bump to 0.6.1, fix typos and add docs strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kubewarden-policy-sdk"
 description = "Kubewarden Policy SDK for the Rust language"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.6.0"
+version = "0.6.1"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"

--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -16,9 +16,10 @@ pub enum CallbackRequestType {
         /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,
     },
+
     /// Require the verification of the manifest digest of an OCI object (be
     /// it an image or anything else that can be stored into an OCI registry)
-    /// to be signed by Sigstore
+    /// to be signed by Sigstore, using public keys mode
     SigstorePubKeyVerify {
         /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,
@@ -27,6 +28,9 @@ pub enum CallbackRequestType {
         /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
         annotations: Option<HashMap<String, String>>,
     },
+
+    // Require the verification of the manifest digest of an OCI object to be
+    // signed by Sigstore, using keyless mode
     SigstoreKeylessVerify {
         /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,
@@ -36,6 +40,8 @@ pub enum CallbackRequestType {
         annotations: Option<HashMap<String, String>>,
     },
 
+    // Require the verification of the manifest digest of an OCI object to be
+    // signed by Sigstore using keyless mode and performed in GitHub Actions
     SigstoreKeylessPrefixVerify {
         /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,
@@ -45,6 +51,8 @@ pub enum CallbackRequestType {
         annotations: Option<HashMap<String, String>>,
     },
 
+    // Require the verification of the manifest digest of an OCI object to be
+    // signed by Sigstore using keyless mode and performed in GitHub Actions
     SigstoreGithubActionsVerify {
         /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,

--- a/src/host_capabilities/verification.rs
+++ b/src/host_capabilities/verification.rs
@@ -63,8 +63,8 @@ pub fn verify_keyless_exact_match(
 }
 
 /// verify sigstore signatures of an image using keyless. Here, the provided
-/// subject string is streated as a URL prefix, and sanitized to a valid URL on
-/// itself by appending `\` to prevent typosquatting. Then, the provided subject
+/// subject string is treated as a URL prefix, and sanitized to a valid URL on
+/// itself by appending `/` to prevent typosquatting. Then, the provided subject
 /// will satisfy the signature only if it is a prefix of the signature subject.
 /// # Arguments
 /// * `image` -  image to be verified


### PR DESCRIPTION
## Description

Follow-up of https://github.com/kubewarden/policy-sdk-rust/pull/46, which I merged prematurely.
