### PR TITLE
fix!: Bump ProtocolVersion to V2, bump Cargo.toml version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kubewarden-policy-sdk"
 description = "Kubewarden Policy SDK for the Rust language"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.6.2"
+version = "0.6.3"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,7 @@ mod tests {
         let reponse = protocol_version_guest(&[0; 0]).unwrap();
         let version: ProtocolVersion = serde_json::from_slice(&reponse).unwrap();
 
-        assert_eq!(version, ProtocolVersion::V1);
+        assert_eq!(version, ProtocolVersion::V2);
         Ok(())
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -14,11 +14,13 @@ pub enum ProtocolVersion {
     Unknown = 0,
     #[serde(rename = "v1")]
     V1,
+    #[serde(rename = "v2")]
+    V2,
 }
 
 impl Default for ProtocolVersion {
     fn default() -> Self {
-        Self::V1
+        Self::V2
     }
 }
 
@@ -45,6 +47,9 @@ mod tests {
 
     #[test]
     fn protocol_version_try_display() {
+        let version = ProtocolVersion::V2;
+        assert_eq!("2", format!("{}", version));
+
         let version = ProtocolVersion::V1;
         assert_eq!("1", format!("{}", version));
 
@@ -57,6 +62,10 @@ mod tests {
         let version = ProtocolVersion::try_from(b"\"v1\"".to_vec());
         assert!(version.is_ok());
         assert_eq!(version.unwrap(), ProtocolVersion::V1);
+
+        let version = ProtocolVersion::try_from(b"\"v2\"".to_vec());
+        assert!(version.is_ok());
+        assert_eq!(version.unwrap(), ProtocolVersion::V2);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Bump ProtocolVersion to V2. This will be reported by policies when consuming the sdk, and expected
by policy-evaluator, which allows us to correctly error when instantiating policies in an old policy-server.

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/policy-evaluator/pull/152
Relates to  https://github.com/kubewarden/policy-sdk-rust/issues/40
Relates to  https://github.com/kubewarden/policy-sdk-rust/issues/41

## Test

Deferring testing until I have policy-evaluator/server/and a policy.

## Additional Information

Needs a 0.6.3 tag in main once it lands.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
