### PR TITLE
Add Github actions and subject prefix verification to sdk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kubewarden-policy-sdk"
 description = "Kubewarden Policy SDK for the Rust language"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.6.2"
+version = "0.6.3"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"

--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -46,9 +46,72 @@ impl Into<CallbackRequestType> for SigstoreVerificationInputV1{
         }
     }
 }
-// internal tag
-pub enum SigstoreVerificationInputV2 {
 
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "type")]
+pub enum SigstoreVerificationInputV2 {
+    /// Require the verification of the manifest digest of an OCI object (be
+    /// it an image or anything else that can be stored into an OCI registry)
+    /// to be signed by Sigstore, using public keys mode
+    SigstorePubKeyVerify {
+        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
+        image: String,
+        /// List of PEM encoded keys that must have been used to sign the OCI object
+        pub_keys: Vec<String>,
+        /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
+        annotations: Option<HashMap<String, String>>,
+    },
+
+    // Require the verification of the manifest digest of an OCI object to be
+    // signed by Sigstore, using keyless mode
+    SigstoreKeylessVerify {
+        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
+        image: String,
+        /// List of keyless signatures that must be found
+        keyless: Vec<KeylessInfo>,
+        /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
+        annotations: Option<HashMap<String, String>>,
+    },
+
+    // Require the verification of the manifest digest of an OCI object to be
+    // signed by Sigstore using keyless mode, where the passed subject is a URL
+    // prefix of the subject to match
+    SigstoreKeylessPrefixVerify {
+        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
+        image: String,
+        /// List of keyless signatures that must be found
+        keyless_prefix: Vec<KeylessPrefixInfo>,
+        /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
+        annotations: Option<HashMap<String, String>>,
+    },
+
+    // Require the verification of the manifest digest of an OCI object to be
+    // signed by Sigstore using keyless mode and performed in GitHub Actions
+    SigstoreGithubActionsVerify {
+        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
+        image: String,
+        /// owner of the repository. E.g: octocat
+        owner: String,
+        /// Optional - Repo of the GH Action workflow that signed the artifact. E.g: example-repo
+        repo: Option<String>,
+        /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
+        annotations: Option<HashMap<String, String>>,
+    }
+}
+
+impl From<SigstoreVerificationInputV2> for CallbackRequestType{
+    fn from(val: SigstoreVerificationInputV2) -> Self {
+        match val {
+            SigstoreVerificationInputV2::SigstorePubKeyVerify { image, pub_keys, annotations } =>
+                CallbackRequestType::SigstorePubKeyVerify {image, pub_keys, annotations},
+            SigstoreVerificationInputV2::SigstoreKeylessVerify { image, keyless, annotations } =>
+                CallbackRequestType::SigstoreKeylessVerify {image, keyless, annotations},
+            SigstoreVerificationInputV2::SigstoreKeylessPrefixVerify { image, keyless_prefix, annotations } =>
+                CallbackRequestType::SigstoreKeylessPrefixVerify {image, keyless_prefix, annotations},
+            SigstoreVerificationInputV2::SigstoreGithubActionsVerify { image, owner, repo, annotations } =>
+                CallbackRequestType::SigstoreGithubActionsVerify {image, owner, repo, annotations},
+        }
+    }
 }
 
 /// Describes the different kinds of request a waPC guest can make to

--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -6,6 +6,7 @@ pub mod net;
 pub mod oci;
 pub mod verification;
 
+/// SigstoreVerificationInputV1 is used for the v1/verify callback
 #[derive(Serialize, Deserialize, Debug)]
 pub enum SigstoreVerificationInputV1 {
     /// Require the verification of the manifest digest of an OCI object (be
@@ -32,6 +33,8 @@ pub enum SigstoreVerificationInputV1 {
     },
 }
 
+/// SigstoreVerificationInputV2 is used for the v2/verify callback
+/// From now on we use serde internally tagged.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "type")]
 pub enum SigstoreVerificationInputV2 {

--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -6,6 +6,51 @@ pub mod net;
 pub mod oci;
 pub mod verification;
 
+#[derive(Serialize, Deserialize, Debug)]
+pub enum SigstoreVerificationInputV1 {
+    /// Require the verification of the manifest digest of an OCI object (be
+    /// it an image or anything else that can be stored into an OCI registry)
+    /// to be signed by Sigstore, using public keys mode
+    SigstorePubKeyVerify {
+        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
+        image: String,
+        /// List of PEM encoded keys that must have been used to sign the OCI object
+        pub_keys: Vec<String>,
+        /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
+        annotations: Option<HashMap<String, String>>,
+    },
+
+    // Require the verification of the manifest digest of an OCI object to be
+    // signed by Sigstore, using keyless mode
+    SigstoreKeylessVerify {
+        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
+        image: String,
+        /// List of keyless signatures that must be found
+        keyless: Vec<KeylessInfo>,
+        /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
+        annotations: Option<HashMap<String, String>>,
+    },
+}
+
+impl Into<CallbackRequestType> for SigstoreVerificationInputV1{
+    fn into(self) -> CallbackRequestType {
+        match self {
+            SigstoreVerificationInputV1::SigstorePubKeyVerify { image, pub_keys, annotations} => {CallbackRequestType::SigstorePubKeyVerify {
+                image,
+                pub_keys,
+                annotations
+            }},
+            SigstoreVerificationInputV1::SigstoreKeylessVerify { image, keyless, annotations } => {
+                CallbackRequestType::SigstoreKeylessVerify {image, keyless, annotations}
+            }
+        }
+    }
+}
+// internal tag
+pub enum SigstoreVerificationInputV2 {
+
+}
+
 /// Describes the different kinds of request a waPC guest can make to
 /// our host.
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -32,21 +32,6 @@ pub enum SigstoreVerificationInputV1 {
     },
 }
 
-impl Into<CallbackRequestType> for SigstoreVerificationInputV1{
-    fn into(self) -> CallbackRequestType {
-        match self {
-            SigstoreVerificationInputV1::SigstorePubKeyVerify { image, pub_keys, annotations} => {CallbackRequestType::SigstorePubKeyVerify {
-                image,
-                pub_keys,
-                annotations
-            }},
-            SigstoreVerificationInputV1::SigstoreKeylessVerify { image, keyless, annotations } => {
-                CallbackRequestType::SigstoreKeylessVerify {image, keyless, annotations}
-            }
-        }
-    }
-}
-
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "type")]
 pub enum SigstoreVerificationInputV2 {
@@ -96,83 +81,5 @@ pub enum SigstoreVerificationInputV2 {
         repo: Option<String>,
         /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
         annotations: Option<HashMap<String, String>>,
-    }
-}
-
-impl From<SigstoreVerificationInputV2> for CallbackRequestType{
-    fn from(val: SigstoreVerificationInputV2) -> Self {
-        match val {
-            SigstoreVerificationInputV2::SigstorePubKeyVerify { image, pub_keys, annotations } =>
-                CallbackRequestType::SigstorePubKeyVerify {image, pub_keys, annotations},
-            SigstoreVerificationInputV2::SigstoreKeylessVerify { image, keyless, annotations } =>
-                CallbackRequestType::SigstoreKeylessVerify {image, keyless, annotations},
-            SigstoreVerificationInputV2::SigstoreKeylessPrefixVerify { image, keyless_prefix, annotations } =>
-                CallbackRequestType::SigstoreKeylessPrefixVerify {image, keyless_prefix, annotations},
-            SigstoreVerificationInputV2::SigstoreGithubActionsVerify { image, owner, repo, annotations } =>
-                CallbackRequestType::SigstoreGithubActionsVerify {image, owner, repo, annotations},
-        }
-    }
-}
-
-/// Describes the different kinds of request a waPC guest can make to
-/// our host.
-#[derive(Serialize, Deserialize, Debug)]
-pub enum CallbackRequestType {
-    /// Require the computation of the manifest digest of an OCI object (be
-    /// it an image or anything else that can be stored into an OCI registry)
-    OciManifestDigest {
-        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
-        image: String,
     },
-
-    /// Require the verification of the manifest digest of an OCI object (be
-    /// it an image or anything else that can be stored into an OCI registry)
-    /// to be signed by Sigstore, using public keys mode
-    SigstorePubKeyVerify {
-        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
-        image: String,
-        /// List of PEM encoded keys that must have been used to sign the OCI object
-        pub_keys: Vec<String>,
-        /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
-        annotations: Option<HashMap<String, String>>,
-    },
-
-    // Require the verification of the manifest digest of an OCI object to be
-    // signed by Sigstore, using keyless mode
-    SigstoreKeylessVerify {
-        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
-        image: String,
-        /// List of keyless signatures that must be found
-        keyless: Vec<KeylessInfo>,
-        /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
-        annotations: Option<HashMap<String, String>>,
-    },
-
-    // Require the verification of the manifest digest of an OCI object to be
-    // signed by Sigstore using keyless mode, where the passed subject is a URL
-    // prefix of the subject to match
-    SigstoreKeylessPrefixVerify {
-        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
-        image: String,
-        /// List of keyless signatures that must be found
-        keyless_prefix: Vec<KeylessPrefixInfo>,
-        /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
-        annotations: Option<HashMap<String, String>>,
-    },
-
-    // Require the verification of the manifest digest of an OCI object to be
-    // signed by Sigstore using keyless mode and performed in GitHub Actions
-    SigstoreGithubActionsVerify {
-        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
-        image: String,
-        /// owner of the repository. E.g: octocat
-        owner: String,
-        /// Optional - Repo of the GH Action workflow that signed the artifact. E.g: example-repo
-        repo: Option<String>,
-        /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
-        annotations: Option<HashMap<String, String>>,
-    },
-
-    /// Lookup the addresses for a given hostname via DNS
-    DNSLookupHost { host: String },
 }


### PR DESCRIPTION
Add GitHub actions and subject prefix sigstore verification to sdk, so we can use them in the policies.
Pass SigstoreVerificationInputV1 and SigstoreVerificationInputV2 to wapc instead of using CallBackRequestType directly 

Relates #40 
Relates #41 

