### PR TITLE
feat: function to mutate the pod spec.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,4 @@ assert-json-diff = "2.0.2"
 mockall = "0.11.2"
 serial_test = "0.9.0"
 k8s-openapi = { version = "0.15.0", default-features = false, features = [ "v1_24" ] }
+jsonpath_lib = "0.3.0"


### PR DESCRIPTION
Adds a new function in the SDK to help policy developers to mutate pod spec from the high level resources (e.g. deployment, statefulset, replicaset, etc).

Fix #63 