### PR TITLE
Bump version v0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kubewarden-policy-sdk"
 description = "Kubewarden Policy SDK for the Rust language"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.7.0"
+version = "0.8.0"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"


### PR DESCRIPTION
Updates the Cargo.toml bumping the SDK version to v0.8.0. This version includes a new function to help policy authors to mutate Pod spec from high level resources types (e.g. deployment, replicaset, cronjob, etc).
