### PR TITLE
fix: handle default features being disabled

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,9 +30,15 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@v1
+      - name: test with default features enabled
+        uses: actions-rs/cargo@v1
         with:
           command: test
+      - name: test with default features disabled
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features
 
   fmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kubewarden-policy-sdk"
 description = "Kubewarden Policy SDK for the Rust language"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.8.1"
+version = "0.8.2"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"
@@ -16,6 +16,7 @@ cluster-context = [ "dep:k8s-openapi" ]
 
 [dependencies]
 anyhow = "1.0"
+cfg-if = "1.0"
 # Starting from k8s-openapi v0.14, it is NOT recommended to be explicit about
 # the kubernetes features to be used when building a library. That's because
 # the final version of the k8s API to be supported must be made by the consumer

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ fmt:
 lint:
 	cargo clippy -- -D warnings
 
-
 .PHONY: test
 test: fmt lint
 	cargo test
+	cargo test --no-default-features
 
 .PHONY: clean
 clean:

--- a/src/request.rs
+++ b/src/request.rs
@@ -2,10 +2,14 @@ use anyhow::anyhow;
 use serde::{de::DeserializeOwned, Deserialize};
 use std::collections::{HashMap, HashSet};
 
-use k8s_openapi::api::apps::v1::{DaemonSet, Deployment, ReplicaSet, StatefulSet};
-use k8s_openapi::api::batch::v1::{CronJob, Job};
-use k8s_openapi::api::core::v1::{Pod, PodSpec, ReplicationController};
-use k8s_openapi::Resource;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "cluster-context")] {
+        use k8s_openapi::api::apps::v1::{DaemonSet, Deployment, ReplicaSet, StatefulSet};
+        use k8s_openapi::api::batch::v1::{CronJob, Job};
+        use k8s_openapi::api::core::v1::{Pod, PodSpec, ReplicationController};
+        use k8s_openapi::Resource;
+    }
+}
 
 /// ValidationRequest holds the data provided to the policy at evaluation time
 #[derive(Deserialize, Debug, Clone)]
@@ -158,6 +162,7 @@ where
         })
     }
 
+    #[cfg(feature = "cluster-context")]
     /// Extract PodSpec from high level objects. This method can be used to evaluate high level objects instead of just Pods.
     /// For example, it can be used to reject Deployments or StatefulSets that violate a policy instead of the Pods created by them.
     /// Objects supported are: Deployment, ReplicaSet, StatefulSet, DaemonSet, ReplicationController, Job, CronJob, Pod
@@ -204,6 +209,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg(feature = "cluster-context")]
 mod tests {
     use super::*;
     use k8s_openapi::api::apps::v1::{


### PR DESCRIPTION
When the default features are disabled, the k8s-openapi crate is no longer required.

The recent helpers introduced to deal with Kubernetes resources containing Pod didn't take that into account.

That causes the library to not compile properly when the imported without the default features.

This commit fixes this and extends our unit tests to ensure this won't happen again.
