### PR TITLE
feat: Add host_capabilities::crypto::verify_cert()

### DIFF
--- a/src/host_capabilities/crypto.rs
+++ b/src/host_capabilities/crypto.rs
@@ -1,0 +1,41 @@
+use crate::host_capabilities::crypto_v1::{
+    CertificateVerificationRequest, CertificateVerificationResponse,
+};
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+
+/// A x509 certificate
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+pub struct Certificate {
+    /// Which encoding is used by the certificate
+    pub encoding: CertificateEncoding,
+    /// Actual certificate
+    pub data: Vec<u8>,
+}
+
+/// The encoding of the certificate
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+pub enum CertificateEncoding {
+    #[allow(missing_docs)]
+    Der,
+    #[allow(missing_docs)]
+    Pem,
+}
+
+/// Verify_cert verifies cert against the passed cert_chain
+pub fn verify_cert(cert: Certificate, cert_chain: Option<Vec<Certificate>>) -> Result<bool> {
+    let req = CertificateVerificationRequest { cert, cert_chain };
+    let msg = serde_json::to_vec(&req).map_err(|e| {
+        anyhow!(
+            "error serializing the certificate verification request: {}",
+            e
+        )
+    })?;
+    let response_raw =
+        wapc_guest::host_call("kubewarden", "crypto", "v1/is_certificate_trusted", &msg)
+            .map_err(|e| anyhow!("{}", e))?;
+
+    let response: CertificateVerificationResponse = serde_json::from_slice(&response_raw)?;
+
+    Ok(response.trusted)
+}

--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -2,6 +2,7 @@ use crate::host_capabilities::verification::{KeylessInfo, KeylessPrefixInfo};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+pub mod crypto;
 pub mod net;
 pub mod oci;
 pub mod verification;
@@ -85,4 +86,24 @@ pub enum SigstoreVerificationInputV2 {
         /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
         annotations: Option<HashMap<String, String>>,
     },
+}
+
+pub mod crypto_v1 {
+    use crate::host_capabilities::crypto::Certificate;
+    use serde::{Deserialize, Serialize};
+
+    /// CertificateVerificationRequest holds information about a certificate and
+    /// a chain to validate it with.
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct CertificateVerificationRequest {
+        /// PEM-encoded certificate
+        pub cert: Certificate,
+        /// list of PEM-encoded certs, ordered by trust usage (intermediates first, root last)
+        pub cert_chain: Option<Vec<Certificate>>,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct CertificateVerificationResponse {
+        pub trusted: bool,
+    }
 }


### PR DESCRIPTION
## Description

Needed by https://github.com/kubewarden/policy-evaluator/issues/200.

This new sdk function verifies a cert against a passed cert_chain.

It uses the new host callback
`kubewarden/crypto/v1/is_certificate_trusted`.

The new `crypto` callback json request and response are specified in the new `crypto_v1` module.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

Tested in policy-evaluator.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
