### PR TITLE
sigstore cert verification

### DIFF
--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -86,6 +86,28 @@ pub enum SigstoreVerificationInputV2 {
         /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
         annotations: Option<HashMap<String, String>>,
     },
+
+    /// Require the verification of the manifest digest of an OCI object
+    /// using the user provided certificate
+    SigstoreCertificateVerify {
+        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
+        image: String,
+        /// PEM encoded certificate used to verify the signature
+        certificate: Vec<u8>,
+        /// Optional - the certificate chain that is used to verify the provided
+        /// certificate. When not specified, the certificate is assumed to be trusted
+        certificate_chain: Option<Vec<Vec<u8>>>,
+        /// Require the  signature layer to have a Rekor bundle.
+        /// Having a Rekor bundle allows further checks to be performed,
+        /// like ensuring the signature has been produced during the validity
+        /// time frame of the certificate.
+        ///
+        /// It is recommended to set this value to `true` to have a more secure
+        /// verification process.
+        require_rekor_bundle: bool,
+        /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
+        annotations: Option<HashMap<String, String>>,
+    },
 }
 
 pub mod crypto_v1 {

--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -22,8 +22,8 @@ pub enum SigstoreVerificationInputV1 {
         annotations: Option<HashMap<String, String>>,
     },
 
-    // Require the verification of the manifest digest of an OCI object to be
-    // signed by Sigstore, using keyless mode
+    /// Require the verification of the manifest digest of an OCI object to be
+    /// signed by Sigstore, using keyless mode
     SigstoreKeylessVerify {
         /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,
@@ -51,8 +51,8 @@ pub enum SigstoreVerificationInputV2 {
         annotations: Option<HashMap<String, String>>,
     },
 
-    // Require the verification of the manifest digest of an OCI object to be
-    // signed by Sigstore, using keyless mode
+    /// Require the verification of the manifest digest of an OCI object to be
+    /// signed by Sigstore, using keyless mode
     SigstoreKeylessVerify {
         /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,
@@ -62,9 +62,9 @@ pub enum SigstoreVerificationInputV2 {
         annotations: Option<HashMap<String, String>>,
     },
 
-    // Require the verification of the manifest digest of an OCI object to be
-    // signed by Sigstore using keyless mode, where the passed subject is a URL
-    // prefix of the subject to match
+    /// Require the verification of the manifest digest of an OCI object to be
+    /// signed by Sigstore using keyless mode, where the passed subject is a URL
+    /// prefix of the subject to match
     SigstoreKeylessPrefixVerify {
         /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,
@@ -74,8 +74,8 @@ pub enum SigstoreVerificationInputV2 {
         annotations: Option<HashMap<String, String>>,
     },
 
-    // Require the verification of the manifest digest of an OCI object to be
-    // signed by Sigstore using keyless mode and performed in GitHub Actions
+    /// Require the verification of the manifest digest of an OCI object to be
+    /// signed by Sigstore using keyless mode and performed in GitHub Actions
     SigstoreGithubActionsVerify {
         /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,


### PR DESCRIPTION
Extend the sigstore verification capabilities to allow usage of certificates.

Required to implement https://github.com/kubewarden/verify-image-signatures/issues/39
