### PR TITLE
fix!: Make `verify_cert()`, return `Result<BoolWithReason>` & bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kubewarden-policy-sdk"
 description = "Kubewarden Policy SDK for the Rust language"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.8.4"
+version = "0.8.5"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",

--- a/src/host_capabilities/crypto.rs
+++ b/src/host_capabilities/crypto.rs
@@ -23,9 +23,25 @@ pub enum CertificateEncoding {
 }
 
 /// Used as return of verify_cert()
+#[derive(Debug)]
 pub enum BoolWithReason {
     True,
     False(String),
+}
+
+impl From<BoolWithReason> for CertificateVerificationResponse {
+    fn from(b: BoolWithReason) -> CertificateVerificationResponse {
+        match b {
+            BoolWithReason::True => CertificateVerificationResponse {
+                trusted: true,
+                reason: "".to_string(),
+            },
+            BoolWithReason::False(reason) => CertificateVerificationResponse {
+                trusted: false,
+                reason,
+            },
+        }
+    }
 }
 
 /// Verify_cert verifies cert's trust against the passed cert_chain, and

--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -131,5 +131,7 @@ pub mod crypto_v1 {
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub struct CertificateVerificationResponse {
         pub trusted: bool,
+        /// empty when trusted is true
+        pub reason: String,
     }
 }


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/verify-image-signatures/pull/47#discussion_r1034836373

Make `verify_cert()`, return `Result<SDK::BoolWithReason>`. Response either returns:
* `Ok(BoolWithReason::True)`.
* `Ok(BoolWithReason::False((reason))` with ``reason` such as "cert not trusted by cert
  chain", or "cert expired".
* `Err(e)`, with `e` such as "cert not in PEM format", or "not_after
  datetime not in RFC 3339 format".


Bump version to 0.8.5

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

No need.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
