### PR TITLE
Tag v0.8.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kubewarden-policy-sdk"
 description = "Kubewarden Policy SDK for the Rust language"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.8.6"
+version = "0.8.7"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",


### PR DESCRIPTION
* Update to latest version of the k8s-openapi crate

We need that to ensure the same version of k8s-openapi is being used by the entire stack
