### PR TITLE
0.9.3 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kubewarden-policy-sdk"
 description = "Kubewarden Policy SDK for the Rust language"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.9.2"
+version = "0.9.3"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",
@@ -13,7 +13,10 @@ license = "Apache-2.0"
 
 [features]
 default = [ "cluster-context" ]
-cluster-context = [ "dep:k8s-openapi" ]
+cluster-context = [ "k8s-openapi" ]
+
+[package.metadata.docs.rs]
+features = ["k8s-openapi/v1_26"]
 
 [dependencies]
 anyhow = "1.0"
@@ -51,3 +54,4 @@ mockall = "0.11.3"
 serial_test = "1.0.0"
 k8s-openapi = { version = "0.17.0", default-features = false, features = [ "v1_24" ] }
 jsonpath_lib = "0.3.0"
+


### PR DESCRIPTION
Fix doc.rs builds: ensure the documentation is built

Fixes https://github.com/kubewarden/policy-sdk-rust/issues/88

I've tested the fix running doc.rs locally
