### PR TITLE
automation(renovate): pin GH actions by digest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "extends": [
     "config:base",
     "group:allNonMajor",
-    "schedule:earlyMondays"
+    "schedule:earlyMondays",
+    "helpers:pinGitHubActionDigests"
   ],
   "labels": ["dependencies"]
 }


### PR DESCRIPTION
Configure renovate bot to pin GH actions using their digest, as documented [here](https://docs.renovatebot.com/modules/manager/github-actions/#additional-information)
