### PR TITLE
fix: breaking change done by 0.9.5 release

### DIFF
--- a/src/host_capabilities/crypto.rs
+++ b/src/host_capabilities/crypto.rs
@@ -15,11 +15,17 @@ pub struct Certificate {
 
 /// The encoding of the certificate
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
-#[serde(rename_all = "lowercase")]
 pub enum CertificateEncoding {
     #[allow(missing_docs)]
+    // Be explicit about how the name should be handled
+    // see https://github.com/kubewarden/policy-sdk-rust/issues/105
+    #[serde(rename = "Der")]
     Der,
+
     #[allow(missing_docs)]
+    // Be explicit about how the name should be handled
+    // see https://github.com/kubewarden/policy-sdk-rust/issues/105
+    #[serde(rename = "Pem")]
     Pem,
 }
 


### PR DESCRIPTION
The 0.9.5 release of this crate broke the `v1/is_certificate_trusted` host capability.

The break was introduced by commit 3dbead4485f0618129835dbdc2d58fe231ee83f2 which has been reverted by this commit.

Fixes #105
