### PR TITLE
fix: rename list all resources host call

### DIFF
--- a/src/host_capabilities/kubernetes.rs
+++ b/src/host_capabilities/kubernetes.rs
@@ -74,7 +74,7 @@ where
     let msg = serde_json::to_vec(req)
         .map_err(|e| anyhow!("error serializing the list all resources request: {}", e))?;
     let response_raw =
-        wapc_guest::host_call("kubewarden", "kubernetes", "list_all_resources", &msg)
+        wapc_guest::host_call("kubewarden", "kubernetes", "list_resources_all", &msg)
             .map_err(|e| anyhow!("{}", e))?;
 
     serde_json::from_slice(&response_raw).map_err(|e| {


### PR DESCRIPTION
## Description

Renames  `list_all_resources` to `list_resources_all`  
see: https://github.com/kubewarden/policy-evaluator/blob/29cb05045f0faa99bea09d5b58fa17a7ef56fdfa/src/runtimes/wapc/callback.rs#L181
