### PR TITLE
fix: CertificateVerificationRequest{}.not_after as None if empty

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ num-traits = "0.2"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9.31"
+serde_with = { version = "3.6.1", features = ["macros"] }
 slog = "2.7.0"
 url = { version = "2.5.0", features = ["serde"] }
 wapc-guest = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ num-traits = "0.2"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9.31"
-serde_with = { version = "3.6.1", features = ["macros"] }
 slog = "2.7.0"
 url = { version = "2.5.0", features = ["serde"] }
 wapc-guest = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kubewarden-policy-sdk"
 description = "Kubewarden Policy SDK for the Rust language"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.9.10"
+version = "0.9.11"
 authors = [
   "Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>",
   "Flavio Castelli <fcastelli@suse.com>",

--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -115,11 +115,9 @@ pub enum SigstoreVerificationInputV2 {
 pub mod crypto_v1 {
     use crate::host_capabilities::crypto::Certificate;
     use serde::{Deserialize, Serialize};
-    use serde_with::{serde_as, NoneAsEmptyString};
 
     /// CertificateVerificationRequest holds information about a certificate and
     /// a chain to validate it with.
-    #[serde_as]
     #[derive(Serialize, Deserialize, Debug)]
     pub struct CertificateVerificationRequest {
         /// PEM-encoded certificate
@@ -129,8 +127,46 @@ pub mod crypto_v1 {
         pub cert_chain: Option<Vec<Certificate>>,
         /// RFC 3339 time format string, to check expiration against. If None,
         /// certificate is assumed never expired
-        #[serde_as(as = "NoneAsEmptyString")]
+        #[serde(with = "optional_string_as_none")]
         pub not_after: Option<String>,
+    }
+
+    /// Custom serialization and deserialization method. Ensure Some("") is serialized/deserialized
+    /// as None
+    mod optional_string_as_none {
+        use serde::{Deserialize, Deserializer, Serializer};
+
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            Ok(Option::<String>::deserialize(deserializer)?.and_then(|s| {
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(s)
+                }
+            }))
+        }
+
+        pub fn serialize<S>(
+            optional_string: &Option<String>,
+            serializer: S,
+        ) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            match optional_string {
+                Some(s) => {
+                    if s.is_empty() {
+                        serializer.serialize_none()
+                    } else {
+                        serializer.serialize_some(s)
+                    }
+                }
+                None => serializer.serialize_none(),
+            }
+        }
     }
 
     #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -138,5 +174,49 @@ pub mod crypto_v1 {
         pub trusted: bool,
         /// empty when trusted is true
         pub reason: String,
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use serde_json::json;
+
+        #[test]
+        fn certificate_verification_request_handle_serialization_with_empty_not_after() {
+            let data = "hello world".as_bytes().to_owned();
+            let request = CertificateVerificationRequest {
+                cert: Certificate {
+                    encoding: crate::host_capabilities::crypto::CertificateEncoding::Pem,
+                    data,
+                },
+                cert_chain: None,
+                not_after: Some("".to_owned()),
+            };
+
+            let request_json = serde_json::to_value(request).unwrap();
+            println!("CIAO {:?}", request_json);
+            let request_obj = request_json
+                .as_object()
+                .expect("cannot convert json data back to an object");
+            assert_eq!(
+                Some(&serde_json::Value::Null),
+                request_obj.get(&"not_after".to_owned())
+            );
+        }
+
+        #[test]
+        fn certificate_verification_request_handle_deserialization_with_empty_not_after() {
+            let data = "hello world".as_bytes().to_owned();
+            let input = json!({
+                "cert": {
+                    "encoding": "Pem",
+                    "data": data
+                },
+                "not_after": ""
+            });
+
+            let request: CertificateVerificationRequest = serde_json::from_value(input).unwrap();
+            assert!(request.not_after.is_none());
+        }
     }
 }

--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -115,9 +115,11 @@ pub enum SigstoreVerificationInputV2 {
 pub mod crypto_v1 {
     use crate::host_capabilities::crypto::Certificate;
     use serde::{Deserialize, Serialize};
+    use serde_with::{serde_as, NoneAsEmptyString};
 
     /// CertificateVerificationRequest holds information about a certificate and
     /// a chain to validate it with.
+    #[serde_as]
     #[derive(Serialize, Deserialize, Debug)]
     pub struct CertificateVerificationRequest {
         /// PEM-encoded certificate
@@ -127,6 +129,7 @@ pub mod crypto_v1 {
         pub cert_chain: Option<Vec<Certificate>>,
         /// RFC 3339 time format string, to check expiration against. If None,
         /// certificate is assumed never expired
+        #[serde_as(as = "NoneAsEmptyString")]
         pub not_after: Option<String>,
     }
 


### PR DESCRIPTION
## Description

`CertificateVerificationRequest{}.not_after` is an `Option`. if `Some`,
it is taken into account to check the certificate against the date,
here:
https://github.com/kubewarden/policy-evaluator/blob/71270655862d9f53bc23feafb3c4e9b4ed982bef/src/callback_handler/crypto.rs#L52-L54

Still, since this is a callback, it may happen that the guest caller
provides a `CertificateVerificationRequest{}` where its
`CertificateVerificationRequest{}.not_after` is present, yet set to the
empty string.
It would then deserialize to `Some("")` instead of `None`. This would
incorrectly skip the expiration check.

Hence, ensure that on (de)serialization on the host, we consider empty
strings as `None`.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

Another option is to, instead of checking this in the Rust SDK that gets used by the host, make sure that all guest SDKs are sending `CertificateVerificationRequest{}` which don't set `not_after` if it isn't needed.


### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
