### PR TITLE
chore: add Kubewarden repository badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-Documentation | Continuous integration | License
- -----------------------|--------|----
-[![Documentation](https://img.shields.io/docsrs/kubewarden-policy-sdk)](https://docs.rs/kubewarden-policy-sdk/latest/kubewarden_policy_sdk/) | ![Continuous integration](https://github.com/kubewarden/policy-sdk-rust/workflows/Continuous%20integration/badge.svg) | [![License: Apache 2.0](https://img.shields.io/badge/License-Apache2.0-brightgreen.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Stable](https://img.shields.io/badge/status-stable-brightgreen?style=for-the-badge)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#stable)
+[![Documentation](https://img.shields.io/docsrs/kubewarden-policy-sdk)](https://docs.rs/kubewarden-policy-sdk/latest/kubewarden_policy_sdk/) 
+![Continuous integration](https://github.com/kubewarden/policy-sdk-rust/workflows/Continuous%20integration/badge.svg)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache2.0-brightgreen.svg)](https://opensource.org/licenses/Apache-2.0)
 
 # Kubewarden Rust Policy SDK
 
 This crate provides a SDK that can be used to write [Kubewarden Policies](https://kubewarden.io)
 using the Rust programming language.
+


### PR DESCRIPTION
## Description

Adds the Kubewarden repository badges document the scope and status of the repository in the Kubewarden ecosystem.

Related to https://github.com/kubewarden/kubewarden-controller/issues/727