### PR TITLE
chore: bump version to v0.11.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kubewarden-policy-sdk"
 description = "Kubewarden Policy SDK for the Rust language"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.10.1"
+version = "0.11.0"
 authors = [
   "Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>",
   "Flavio Castelli <fcastelli@suse.com>",


### PR DESCRIPTION
## Description

Bump the version of the SDK to release the new host capability to fetch OCI image manifest and configuration and some dependencies updates.