### PR TITLE
Fix linter, bump k8s-openapi and bump lib version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kubewarden-policy-sdk"
 description = "Kubewarden Policy SDK for the Rust language"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.11.2"
+version = "0.11.3"
 authors = [
   "Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>",
   "Flavio Castelli <fcastelli@suse.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ cfg-if = "1.0"
 # This however can lead to issues when executing commands like
 # cargo `build|check|doc`. That's because the `k8s-openapi` is specified again
 # inside of the `dev-dependencies`, this time with a k8s feature enabled
-k8s-openapi = { version = "0.23.0", default-features = false, optional = true }
+k8s-openapi = { version = "0.24.0", default-features = false, optional = true }
 num = "0.4"
 num-derive = "0.4"
 num-traits = "0.2"
@@ -54,7 +54,7 @@ oci-spec = "0.7.0"
 assert-json-diff = "2.0.2"
 mockall = "0.13.0"
 serial_test = "3.1.1"
-k8s-openapi = { version = "0.23.0", default-features = false, features = [
+k8s-openapi = { version = "0.24.0", default-features = false, features = [
   "v1_31",
 ] }
 jsonpath_lib = "0.3.0"

--- a/src/logging/ser.rs
+++ b/src/logging/ser.rs
@@ -37,7 +37,7 @@ macro_rules! emit_m {
     };
 }
 
-impl<'a> slog::Serializer for KubewardenFieldSerializer<'a> {
+impl slog::Serializer for KubewardenFieldSerializer<'_> {
     emit_m!(emit_u8, u8);
     emit_m!(emit_i8, i8);
     emit_m!(emit_u16, u16);


### PR DESCRIPTION
## Description

Fix linter errors and bumps k8s-openapi to `v0.24.0`. Furthermore,  bump lib version to release the lib bump