### PR TITLE
sigstore verifier refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kubewarden-policy-sdk"
 description = "Kubewarden Policy SDK for the Rust language"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.12.0"
+version = "0.13.0"
 authors = [
   "Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>",
   "Flavio Castelli <fcastelli@suse.com>",

--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -1,6 +1,6 @@
 use crate::host_capabilities::verification::{KeylessInfo, KeylessPrefixInfo};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 pub mod crypto;
 #[cfg(feature = "cluster-context")]
@@ -21,7 +21,7 @@ pub enum SigstoreVerificationInputV1 {
         /// List of PEM encoded keys that must have been used to sign the OCI object
         pub_keys: Vec<String>,
         /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     },
 
     /// Require the verification of the manifest digest of an OCI object to be
@@ -32,7 +32,7 @@ pub enum SigstoreVerificationInputV1 {
         /// List of keyless signatures that must be found
         keyless: Vec<KeylessInfo>,
         /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     },
 }
 
@@ -50,7 +50,7 @@ pub enum SigstoreVerificationInputV2 {
         /// List of PEM encoded keys that must have been used to sign the OCI object
         pub_keys: Vec<String>,
         /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     },
 
     /// Require the verification of the manifest digest of an OCI object to be
@@ -61,7 +61,7 @@ pub enum SigstoreVerificationInputV2 {
         /// List of keyless signatures that must be found
         keyless: Vec<KeylessInfo>,
         /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     },
 
     /// Require the verification of the manifest digest of an OCI object to be
@@ -73,7 +73,7 @@ pub enum SigstoreVerificationInputV2 {
         /// List of keyless signatures that must be found
         keyless_prefix: Vec<KeylessPrefixInfo>,
         /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     },
 
     /// Require the verification of the manifest digest of an OCI object to be
@@ -86,7 +86,7 @@ pub enum SigstoreVerificationInputV2 {
         /// Optional - Repo of the GH Action workflow that signed the artifact. E.g: example-repo
         repo: Option<String>,
         /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     },
 
     /// Require the verification of the manifest digest of an OCI object
@@ -108,7 +108,7 @@ pub enum SigstoreVerificationInputV2 {
         /// verification process.
         require_rekor_bundle: bool,
         /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     },
 }
 

--- a/src/host_capabilities/verification.rs
+++ b/src/host_capabilities/verification.rs
@@ -1,7 +1,7 @@
 use crate::host_capabilities::SigstoreVerificationInputV2;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 #[cfg(test)]
 use tests::mock_wapc as wapc_guest;
 
@@ -42,7 +42,7 @@ pub struct KeylessPrefixInfo {
 pub fn verify_pub_keys_image(
     image: &str,
     pub_keys: Vec<String>,
-    annotations: Option<HashMap<String, String>>,
+    annotations: Option<BTreeMap<String, String>>,
 ) -> Result<VerificationResponse> {
     let input = SigstoreVerificationInputV2::SigstorePubKeyVerify {
         image: image.to_string(),
@@ -61,7 +61,7 @@ pub fn verify_pub_keys_image(
 pub fn verify_keyless_exact_match(
     image: &str,
     keyless: Vec<KeylessInfo>,
-    annotations: Option<HashMap<String, String>>,
+    annotations: Option<BTreeMap<String, String>>,
 ) -> Result<VerificationResponse> {
     let input = SigstoreVerificationInputV2::SigstoreKeylessVerify {
         image: image.to_string(),
@@ -83,7 +83,7 @@ pub fn verify_keyless_exact_match(
 pub fn verify_keyless_prefix_match(
     image: &str,
     keyless_prefix: Vec<KeylessPrefixInfo>,
-    annotations: Option<HashMap<String, String>>,
+    annotations: Option<BTreeMap<String, String>>,
 ) -> Result<VerificationResponse> {
     let input = SigstoreVerificationInputV2::SigstoreKeylessPrefixVerify {
         image: image.to_string(),
@@ -105,7 +105,7 @@ pub fn verify_keyless_github_actions(
     image: &str,
     owner: String,
     repo: Option<String>,
-    annotations: Option<HashMap<String, String>>,
+    annotations: Option<BTreeMap<String, String>>,
 ) -> Result<VerificationResponse> {
     let input = SigstoreVerificationInputV2::SigstoreGithubActionsVerify {
         image: image.to_string(),
@@ -135,7 +135,7 @@ pub fn verify_certificate(
     certificate: String,
     certificate_chain: Option<Vec<String>>,
     require_rekor_bundle: bool,
-    annotations: Option<HashMap<String, String>>,
+    annotations: Option<BTreeMap<String, String>>,
 ) -> Result<VerificationResponse> {
     let chain: Option<Vec<Vec<u8>>> =
         certificate_chain.map(|c| c.iter().map(|cert| cert.as_bytes().to_vec()).collect());


### PR DESCRIPTION
Change the Sigstore verifiers to use `BTreeMap` instead of `HashMap` to store annotations.

This is required by a change done by the latest version of the sigstore-rs crate.

This refactor breaks our Rust API, but it doesn't change the waPC one. These are just two different data structures used to represent hashes

I decided to change the SDK rather to avoid useless conversions inside of the callback handlers of waPC.

I'll tag the 0.13.0 release once this gets mergeed.
