### PR TITLE
build: Bump version to 0.13.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "kubewarden-policy-sdk"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.13.2"
+version = "0.13.3"
 
 [features]
 cluster-context = ["k8s-openapi"]


### PR DESCRIPTION
## Description

Release 1.13.3 consuming oci-spec 0.8.0.
This is needed by some policies that consume oci-spec on their own, e.g: https://github.com/kubewarden/user-group-psp-policy/pull/142.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
