### PR TITLE
 chore: remove actions-rs/toolchain github action.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,9 @@ jobs:
       - ci
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          toolchain: stable
-          override: true
-
+      - name: Setup rust toolchain
+        run: |
+          rustup toolchain install stable 
+          rustup override set stable
       - name: publish crates
         run: cargo publish --token ${{ secrets.CARGO_API_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,11 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: Setup rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal 
+          rustup override set stable
       - name: Run cargo check
         run: cargo check
 
@@ -30,11 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: Setup rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal 
+          rustup override set stable
       - name: test with default features enabled
         run: cargo test
       - name: test with default features disabled
@@ -45,11 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: Setup rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal 
+          rustup override set stable
       - run: rustup component add rustfmt
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
@@ -59,11 +56,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: Setup rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal 
+          rustup override set stable
       - run: rustup component add clippy
       - name: Run cargo clippy
         run: cargo clippy -- -D warnings


### PR DESCRIPTION
## Description

Removes the deprecated actions-rs/toolchain Github actions used to setup Rust toolchains. Replacing it by calls to the rustup command directly relying on the binaries installed in the workflow runner.

Related to https://github.com/kubewarden/kubewarden-controller/issues/1093
