### PR TITLE
chore(deps): use rustsec/audit-check GHA.

### DIFF
--- a/.github/workflows/security-audit-cron.yml
+++ b/.github/workflows/security-audit-cron.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3 # v1.2.0
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 #v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security-audit-reactive.yml
+++ b/.github/workflows/security-audit-reactive.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3 # v1.2.0
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 #v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Replace the deprecated actions-rs/audit-check GHA by a fork under the RustSec organization which is updated and more active.

This is not a final fix for the https://github.com/kubewarden/kubewarden-controller/issues/1091 issue because this action is not in our GHA allowed list. However, while we wait for the security team evaluation of the Rustsec action, let's use it because it has recent [updates](https://github.com/rustsec/audit-check/releases)


