### PR TITLE
feat: custom error message field.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "kubewarden-policy-sdk"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.13.4"
+version = "0.13.5"
 
 [features]
 cluster-context = ["k8s-openapi"]

--- a/src/crd/policies/admission_policy.rs
+++ b/src/crd/policies/admission_policy.rs
@@ -119,6 +119,12 @@ pub struct AdmissionPolicySpec {
     /// The timeout value must be between 1 and 30 seconds.
     /// Default to 10 seconds.
     pub timeout_seconds: Option<TimeoutSeconds>,
+
+    // Message overrides the rejection message of the policy.
+    // When provided, the policy's rejection message can be found
+    // inside of the `.status.details.causes` field of the
+    // AdmissionResponse object
+    pub message: Option<String>,
 }
 
 #[cfg(test)]

--- a/src/crd/policies/cluster_admission_policy.rs
+++ b/src/crd/policies/cluster_admission_policy.rs
@@ -131,6 +131,12 @@ pub struct ClusterAdmissionPolicySpec {
     /// the policy is assigned to.
     #[serde(default)]
     pub context_aware_resources: Vec<ContextAwareResource>,
+
+    // Message overrides the rejection message of the policy.
+    // When provided, the policy's rejection message can be found
+    // inside of the `.status.details.causes` field of the
+    // AdmissionResponse object
+    pub message: Option<String>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description

Updates the AdmissionPolicySpec and ClusterAdmissionPolicySpec struct adding the new `message` field. This field is used to customize the error message returned by the policy.

Fix https://github.com/kubewarden/kubewarden-controller/issues/1141

