### PR TITLE
fix(kubernetes/can-i): follow other capabilities function signatures.

### DIFF
--- a/src/host_capabilities/kubernetes.rs
+++ b/src/host_capabilities/kubernetes.rs
@@ -131,14 +131,7 @@ pub struct SubjectAccessReviewRequest {
     pub disable_cache: bool,
 }
 /// Check if user has permissions to perform an action on resources
-pub fn can_i(
-    subject_access_review: SubjectAccessReview,
-    disable_cache: bool,
-) -> Result<SubjectAccessReviewStatus> {
-    let request = SubjectAccessReviewRequest {
-        subject_access_review,
-        disable_cache,
-    };
+pub fn can_i(request: SubjectAccessReviewRequest) -> Result<SubjectAccessReviewStatus> {
     let msg = serde_json::to_vec(&request)
         .map_err(|e| anyhow!("error serializing the can_i request: {:?}", e))?;
     let response_raw = wapc_guest::host_call("kubewarden", "kubernetes", "can_i", &msg)


### PR DESCRIPTION
## Description

Updates the function exposing the kubernetes/can-i host capability to follow the same standard of the other capabilities. The function will recive the request object as the argument.


