### PR TITLE
Revert "fix(deps): update rust crate schemars to v1"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ num                = "0.4"
 num-derive         = "0.4"
 num-traits         = "0.2"
 oci-spec           = "0.8.0"
-schemars           = { version = "1.0", optional = true }
+schemars           = { version = "0.8", features = ["impl_json_schema"], optional = true }
 serde              = { version = "1.0", features = ["derive"] }
 serde_json         = "1.0"
 serde_yaml         = "0.9.34"


### PR DESCRIPTION
Reverts kubewarden/policy-sdk-rust#175

This is because the bump to schemars v1 needs to happen in lockstep with the rest of dependencies, such as k8s-openapi (which has [bumped](https://github.com/Arnavion/k8s-openapi/commit/e9a9eaf672cf700ee78bd6f267fefc5efa571c7a) it but it hasn't been released yet).

This is only discovered once we consume the sdk via policy-evaluator, too.