### PR TITLE
chore(Cargo.toml): bump v0.14.1 version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "kubewarden-policy-sdk"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.14.0"
+version = "0.14.1"
 
 [features]
 cluster-context = ["k8s-openapi"]


### PR DESCRIPTION
## Description

Updates the Cargo.toml file bumping the version to v0.14.1 releasing the fix in the documentation.