### PR TITLE
chore: v0.14.2 version bump.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "kubewarden-policy-sdk"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.14.1"
+version = "0.14.2"
 
 [features]
 cluster-context = ["k8s-openapi"]


### PR DESCRIPTION
## Description

Bump the SDK version in the Cargo.toml file to v0.14.2.
