### PR TITLE
ci: enable crates.io trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,11 +64,17 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - ci
+    permissions:
+      id-token: write # Required for OIDC token exchange
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup rust toolchain
         run: |
           rustup toolchain install stable 
           rustup override set stable
+      - uses: rust-lang/crates-io-auth-action@e919bc7605cde86df457cf5b93c5e103838bd879 # v1.0.1
+        id: auth
       - name: publish crates
-        run: cargo publish --token ${{ secrets.CARGO_API_TOKEN }}
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Enable https://crates.io/docs/trusted-publishing

All the changes have already been done on crates.io
