### PR TITLE
fix: CertificateVerificationRequest derive Eq and PartialEq.

### DIFF
--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -119,7 +119,7 @@ pub mod crypto_v1 {
 
     /// CertificateVerificationRequest holds information about a certificate and
     /// a chain to validate it with.
-    #[derive(Serialize, Deserialize, Debug)]
+    #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
     pub struct CertificateVerificationRequest {
         /// PEM-encoded certificate
         pub cert: Certificate,

--- a/src/logging/ser.rs
+++ b/src/logging/ser.rs
@@ -13,7 +13,7 @@ impl KubewardenLogSerializer {
         })
     }
 
-    pub fn field_serializer(&mut self) -> KubewardenFieldSerializer {
+    pub fn field_serializer(&mut self) -> KubewardenFieldSerializer<'_> {
         KubewardenFieldSerializer {
             data: &mut self.data,
         }


### PR DESCRIPTION
## Description

Updates the CertificateVerificationRequest struct to derive the Eq and PartialEq trait. This is required to allow the usage of the struct in the CallbackRequestType enum from policy-evaluator.

Required by https://github.com/kubewarden/policy-evaluator/pull/751