### PR TITLE
refactor: derive extra traits for some crypto types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "kubewarden-policy-sdk"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.14.4"
+version = "0.14.5"
 
 [features]
 cluster-context = ["k8s-openapi"]
@@ -40,6 +40,7 @@ cfg-if = "1.0"
 # cargo `build|check|doc`. That's because the `k8s-openapi` is specified again
 # inside of the `dev-dependencies`, this time with a k8s feature enabled
 chrono             = { version = "0.4", default-features = false }
+hex                = "0.4"
 k8s-openapi        = { version = "0.25.0", default-features = false, optional = true }
 k8s-openapi-derive = { version = "0.25.0", optional = true }
 num                = "0.4"


### PR DESCRIPTION
Derive `Serialize` trait and implement the `Display` trait for some of the types of the `crypto` module.

This is required to implement some changes inside of policy-evaluator.

I'll tag a new release of the crate once this is merged.
