### PR TITLE
fix: allow equality comparision for CertificateVerificationResponse.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "kubewarden-policy-sdk"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.14.6"
+version = "0.14.7"
 
 [features]
 cluster-context = ["k8s-openapi"]

--- a/src/host_capabilities/mod.rs
+++ b/src/host_capabilities/mod.rs
@@ -170,7 +170,7 @@ pub mod crypto_v1 {
         }
     }
 
-    #[derive(Serialize, Deserialize, Debug, Clone)]
+    #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
     pub struct CertificateVerificationResponse {
         pub trusted: bool,
         /// empty when trusted is true


### PR DESCRIPTION
## Description

Add the Eq and PartialEq derive for the CertificateVerificationResponse type to allow the comparision in policy-evaluator unit tests.

Related to https://github.com/kubewarden/policy-evaluator/issues/764