### PR TITLE
feat: update Kubewarden CRDs

### DIFF
--- a/src/crd/policies/admission_policy.rs
+++ b/src/crd/policies/admission_policy.rs
@@ -120,6 +120,12 @@ pub struct AdmissionPolicySpec {
     /// Default to 10 seconds.
     pub timeout_seconds: Option<TimeoutSeconds>,
 
+    // TimeoutEvalSeconds specifies the timeout for the policy evaluation. After
+    // the timeout passes, the policy evaluation call will fail based on the
+    // failure policy.
+    // The timeout value must be between 1 and 30 seconds.
+    pub timeout_eval_seconds: Option<TimeoutSeconds>,
+
     // Message overrides the rejection message of the policy.
     // When provided, the policy's rejection message can be found
     // inside of the `.status.details.causes` field of the

--- a/src/crd/policies/admission_policy_group.rs
+++ b/src/crd/policies/admission_policy_group.rs
@@ -28,6 +28,12 @@ pub struct PolicyGroupMember {
     /// Settings is a free-form object that contains the policy configuration
     #[serde(default = "default_settings")]
     pub settings: RawExtension,
+
+    // TimeoutEvalSeconds specifies the timeout for the policy evaluation. After
+    // the timeout passes, the policy evaluation call will fail based on the
+    // failure policy.
+    // The timeout value must be between 1 and 30 seconds.
+    pub timeout_eval_seconds: Option<TimeoutSeconds>,
 }
 
 #[derive(

--- a/src/crd/policies/cluster_admission_policy.rs
+++ b/src/crd/policies/cluster_admission_policy.rs
@@ -120,6 +120,12 @@ pub struct ClusterAdmissionPolicySpec {
     /// Default to 10 seconds.
     pub timeout_seconds: Option<TimeoutSeconds>,
 
+    // TimeoutEvalSeconds specifies the timeout for the policy evaluation. After
+    // the timeout passes, the policy evaluation call will fail based on the
+    // failure policy.
+    // The timeout value must be between 1 and 30 seconds.
+    pub timeout_eval_seconds: Option<TimeoutSeconds>,
+
     /// NamespaceSelector decides whether to run the webhook on an object based on whether the namespace
     /// for that object matches the selector. If the object itself is a namespace, the matching is
     /// performed on object.metadata.labels.

--- a/src/crd/policies/cluster_admission_policy_group.rs
+++ b/src/crd/policies/cluster_admission_policy_group.rs
@@ -34,6 +34,12 @@ pub struct PolicyGroupMemberWithContext {
     /// the policy is assigned to.
     #[serde(default)]
     pub context_aware_resources: Vec<ContextAwareResource>,
+
+    // TimeoutEvalSeconds specifies the timeout for the policy evaluation. After
+    // the timeout passes, the policy evaluation call will fail based on the
+    // failure policy.
+    // The timeout value must be between 1 and 30 seconds.
+    pub timeout_eval_seconds: Option<TimeoutSeconds>,
 }
 
 #[derive(

--- a/src/crd/policies/common.rs
+++ b/src/crd/policies/common.rs
@@ -76,6 +76,24 @@ impl Default for TimeoutSeconds {
     }
 }
 
+impl From<i32> for TimeoutSeconds {
+    fn from(timeout: i32) -> Self {
+        TimeoutSeconds(timeout)
+    }
+}
+
+impl From<TimeoutSeconds> for i32 {
+    fn from(timeout: TimeoutSeconds) -> Self {
+        timeout.0
+    }
+}
+
+impl From<&TimeoutSeconds> for i32 {
+    fn from(timeout: &TimeoutSeconds) -> Self {
+        timeout.0
+    }
+}
+
 pub(crate) fn default_policy_server() -> String {
     "default".to_string()
 }


### PR DESCRIPTION
Add the `timeoutEvalSeconds` attribute to the KW policies CRD.

Also, add some converter traits to the TimeoutSeconds type of the KW CRD.

Required as part of https://github.com/kubewarden/policy-server/pull/1284
