### PR TITLE
Check PodSpec resource group and version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub mod test;
 pub use crate::error::{Error, Result};
 use crate::metadata::ProtocolVersion;
 #[cfg(feature = "cluster-context")]
-use crate::request::{is_resource, supported_pod_spec_objects_message, ValidationRequest};
+use crate::request::{ValidationRequest, is_resource, supported_pod_spec_objects_message};
 use crate::response::*;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "crd")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,79 +72,71 @@ pub fn mutate_pod_spec_from_request<T: std::default::Default>(
     pod_spec: PodSpec,
 ) -> wapc_guest::CallResult {
     let gvk = &validation_request.request.kind;
-    match () {
-        _ if is_resource::<Deployment>(gvk) => {
-            let mut deployment =
-                serde_json::from_value::<Deployment>(validation_request.request.object.clone())?;
-            let mut deployment_spec = deployment.spec.unwrap_or_default();
-            deployment_spec.template.spec = Some(pod_spec);
-            deployment.spec = Some(deployment_spec);
-            mutate_request(serde_json::to_value(deployment)?)
-        }
-        _ if is_resource::<ReplicaSet>(gvk) => {
-            let mut replicaset =
-                serde_json::from_value::<ReplicaSet>(validation_request.request.object.clone())?;
-            let mut replicaset_spec = replicaset.spec.unwrap_or_default();
-            let mut template = replicaset_spec.template.unwrap_or_default();
-            template.spec = Some(pod_spec);
-            replicaset_spec.template = Some(template);
-            replicaset.spec = Some(replicaset_spec);
-            mutate_request(serde_json::to_value(replicaset)?)
-        }
-        _ if is_resource::<StatefulSet>(gvk) => {
-            let mut statefulset =
-                serde_json::from_value::<StatefulSet>(validation_request.request.object.clone())?;
-            let mut statefulset_spec = statefulset.spec.unwrap_or_default();
-            statefulset_spec.template.spec = Some(pod_spec);
-            statefulset.spec = Some(statefulset_spec);
-            mutate_request(serde_json::to_value(statefulset)?)
-        }
-        _ if is_resource::<DaemonSet>(gvk) => {
-            let mut daemonset =
-                serde_json::from_value::<DaemonSet>(validation_request.request.object.clone())?;
-            let mut daemonset_spec = daemonset.spec.unwrap_or_default();
-            daemonset_spec.template.spec = Some(pod_spec);
-            daemonset.spec = Some(daemonset_spec);
-            mutate_request(serde_json::to_value(daemonset)?)
-        }
-        _ if is_resource::<ReplicationController>(gvk) => {
-            let mut replication_controller = serde_json::from_value::<ReplicationController>(
-                validation_request.request.object.clone(),
-            )?;
-            let mut replication_controller_spec = replication_controller.spec.unwrap_or_default();
-            let mut template = replication_controller_spec.template.unwrap_or_default();
-            template.spec = Some(pod_spec);
-            replication_controller_spec.template = Some(template);
-            replication_controller.spec = Some(replication_controller_spec);
-            mutate_request(serde_json::to_value(replication_controller)?)
-        }
-        _ if is_resource::<CronJob>(gvk) => {
-            let mut cronjob =
-                serde_json::from_value::<CronJob>(validation_request.request.object.clone())?;
-            let mut cronjob_spec = cronjob.spec.unwrap_or_default();
-            let mut job_template_spec = cronjob_spec.job_template;
-            let mut job_spec = job_template_spec.spec.unwrap_or_default();
-            let mut pod_template_spec = job_spec.template;
-            pod_template_spec.spec = Some(pod_spec);
-            job_spec.template = pod_template_spec;
-            job_template_spec.spec = Some(job_spec);
-            cronjob_spec.job_template = job_template_spec;
-            cronjob.spec = Some(cronjob_spec);
-            mutate_request(serde_json::to_value(cronjob)?)
-        }
-        _ if is_resource::<Job>(gvk) => {
-            let mut job = serde_json::from_value::<Job>(validation_request.request.object.clone())?;
-            let mut job_spec = job.spec.unwrap_or_default();
-            job_spec.template.spec = Some(pod_spec);
-            job.spec = Some(job_spec);
-            mutate_request(serde_json::to_value(job)?)
-        }
-        _ if is_resource::<Pod>(gvk) => {
-            let mut pod = serde_json::from_value::<Pod>(validation_request.request.object.clone())?;
-            pod.spec = Some(pod_spec);
-            mutate_request(serde_json::to_value(pod)?)
-        }
-        _ => reject_request(Some(supported_pod_spec_objects_message()), None, None, None),
+    if is_resource::<Deployment>(gvk) {
+        let mut deployment =
+            serde_json::from_value::<Deployment>(validation_request.request.object.clone())?;
+        let mut deployment_spec = deployment.spec.unwrap_or_default();
+        deployment_spec.template.spec = Some(pod_spec);
+        deployment.spec = Some(deployment_spec);
+        mutate_request(serde_json::to_value(deployment)?)
+    } else if is_resource::<ReplicaSet>(gvk) {
+        let mut replicaset =
+            serde_json::from_value::<ReplicaSet>(validation_request.request.object.clone())?;
+        let mut replicaset_spec = replicaset.spec.unwrap_or_default();
+        let mut template = replicaset_spec.template.unwrap_or_default();
+        template.spec = Some(pod_spec);
+        replicaset_spec.template = Some(template);
+        replicaset.spec = Some(replicaset_spec);
+        mutate_request(serde_json::to_value(replicaset)?)
+    } else if is_resource::<StatefulSet>(gvk) {
+        let mut statefulset =
+            serde_json::from_value::<StatefulSet>(validation_request.request.object.clone())?;
+        let mut statefulset_spec = statefulset.spec.unwrap_or_default();
+        statefulset_spec.template.spec = Some(pod_spec);
+        statefulset.spec = Some(statefulset_spec);
+        mutate_request(serde_json::to_value(statefulset)?)
+    } else if is_resource::<DaemonSet>(gvk) {
+        let mut daemonset =
+            serde_json::from_value::<DaemonSet>(validation_request.request.object.clone())?;
+        let mut daemonset_spec = daemonset.spec.unwrap_or_default();
+        daemonset_spec.template.spec = Some(pod_spec);
+        daemonset.spec = Some(daemonset_spec);
+        mutate_request(serde_json::to_value(daemonset)?)
+    } else if is_resource::<ReplicationController>(gvk) {
+        let mut replication_controller = serde_json::from_value::<ReplicationController>(
+            validation_request.request.object.clone(),
+        )?;
+        let mut replication_controller_spec = replication_controller.spec.unwrap_or_default();
+        let mut template = replication_controller_spec.template.unwrap_or_default();
+        template.spec = Some(pod_spec);
+        replication_controller_spec.template = Some(template);
+        replication_controller.spec = Some(replication_controller_spec);
+        mutate_request(serde_json::to_value(replication_controller)?)
+    } else if is_resource::<CronJob>(gvk) {
+        let mut cronjob =
+            serde_json::from_value::<CronJob>(validation_request.request.object.clone())?;
+        let mut cronjob_spec = cronjob.spec.unwrap_or_default();
+        let mut job_template_spec = cronjob_spec.job_template;
+        let mut job_spec = job_template_spec.spec.unwrap_or_default();
+        let mut pod_template_spec = job_spec.template;
+        pod_template_spec.spec = Some(pod_spec);
+        job_spec.template = pod_template_spec;
+        job_template_spec.spec = Some(job_spec);
+        cronjob_spec.job_template = job_template_spec;
+        cronjob.spec = Some(cronjob_spec);
+        mutate_request(serde_json::to_value(cronjob)?)
+    } else if is_resource::<Job>(gvk) {
+        let mut job = serde_json::from_value::<Job>(validation_request.request.object.clone())?;
+        let mut job_spec = job.spec.unwrap_or_default();
+        job_spec.template.spec = Some(pod_spec);
+        job.spec = Some(job_spec);
+        mutate_request(serde_json::to_value(job)?)
+    } else if is_resource::<Pod>(gvk) {
+        let mut pod = serde_json::from_value::<Pod>(validation_request.request.object.clone())?;
+        pod.spec = Some(pod_spec);
+        mutate_request(serde_json::to_value(pod)?)
+    } else {
+        reject_request(Some(supported_pod_spec_objects_message()), None, None, None)
     }
 }
 
@@ -250,10 +242,11 @@ mod tests {
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "cluster-context")] {
-            use crate::request::{GroupVersionKind, KubernetesAdmissionRequest};
+            use crate::request::{
+                create_validation_request, create_validation_request_with_gvk,
+            };
 
             use jsonpath_lib as jsonpath;
-            use serde::Serialize;
             use serde::ser::StdError;
 
             use k8s_openapi::api::batch::v1::{CronJob, CronJobSpec, JobSpec, JobTemplateSpec};
@@ -350,44 +343,6 @@ mod tests {
 
         assert_eq!(version, ProtocolVersion::V1);
         Ok(())
-    }
-
-    #[cfg(feature = "cluster-context")]
-    fn create_validation_request<T: Serialize>(object: T, kind: &str) -> ValidationRequest<()> {
-        let (group, version) = group_version_for_kind(kind);
-        create_validation_request_with_gvk(object, group, version, kind)
-    }
-
-    #[cfg(feature = "cluster-context")]
-    fn create_validation_request_with_gvk<T: Serialize>(
-        object: T,
-        group: &str,
-        version: &str,
-        kind: &str,
-    ) -> ValidationRequest<()> {
-        let value = serde_json::to_value(object).unwrap();
-        ValidationRequest {
-            settings: (),
-            request: KubernetesAdmissionRequest {
-                kind: GroupVersionKind {
-                    group: group.to_owned(),
-                    version: version.to_owned(),
-                    kind: kind.to_owned(),
-                },
-                object: value,
-                ..Default::default()
-            },
-        }
-    }
-
-    #[cfg(feature = "cluster-context")]
-    fn group_version_for_kind(kind: &str) -> (&'static str, &'static str) {
-        match kind {
-            "Deployment" | "ReplicaSet" | "StatefulSet" | "DaemonSet" => ("apps", "v1"),
-            "CronJob" | "Job" => ("batch", "v1"),
-            "ReplicationController" | "Pod" => ("", "v1"),
-            _ => ("", ""),
-        }
     }
 
     #[cfg(feature = "cluster-context")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub mod test;
 pub use crate::error::{Error, Result};
 use crate::metadata::ProtocolVersion;
 #[cfg(feature = "cluster-context")]
-use crate::request::ValidationRequest;
+use crate::request::{is_resource, supported_pod_spec_objects_message, ValidationRequest};
 use crate::response::*;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "crd")))]
@@ -31,7 +31,6 @@ cfg_if::cfg_if! {
         use k8s_openapi::api::apps::v1::{DaemonSet, Deployment, ReplicaSet, StatefulSet};
         use k8s_openapi::api::batch::v1::{CronJob, Job};
         use k8s_openapi::api::core::v1::{Pod, PodSpec, ReplicationController};
-        use k8s_openapi::Resource;
     }
 }
 
@@ -63,7 +62,7 @@ pub fn mutate_request(mutated_object: serde_json::Value) -> wapc_guest::CallResu
 
 #[cfg_attr(docsrs, doc(cfg(feature = "cluster-context")))]
 #[cfg(feature = "cluster-context")]
-/// Update the pod sec from the resource defined in the original object
+/// Update the pod spec from the resource defined in the original object
 /// and create an acceptance response.
 /// # Arguments
 /// * `validation_request` - the original admission request
@@ -72,8 +71,9 @@ pub fn mutate_pod_spec_from_request<T: std::default::Default>(
     validation_request: ValidationRequest<T>,
     pod_spec: PodSpec,
 ) -> wapc_guest::CallResult {
-    match validation_request.request.kind.kind.as_str() {
-        Deployment::KIND => {
+    let gvk = &validation_request.request.kind;
+    match () {
+        _ if is_resource::<Deployment>(gvk) => {
             let mut deployment =
                 serde_json::from_value::<Deployment>(validation_request.request.object.clone())?;
             let mut deployment_spec = deployment.spec.unwrap_or_default();
@@ -81,7 +81,7 @@ pub fn mutate_pod_spec_from_request<T: std::default::Default>(
             deployment.spec = Some(deployment_spec);
             mutate_request(serde_json::to_value(deployment)?)
         }
-        ReplicaSet::KIND => {
+        _ if is_resource::<ReplicaSet>(gvk) => {
             let mut replicaset =
                 serde_json::from_value::<ReplicaSet>(validation_request.request.object.clone())?;
             let mut replicaset_spec = replicaset.spec.unwrap_or_default();
@@ -91,7 +91,7 @@ pub fn mutate_pod_spec_from_request<T: std::default::Default>(
             replicaset.spec = Some(replicaset_spec);
             mutate_request(serde_json::to_value(replicaset)?)
         }
-        StatefulSet::KIND => {
+        _ if is_resource::<StatefulSet>(gvk) => {
             let mut statefulset =
                 serde_json::from_value::<StatefulSet>(validation_request.request.object.clone())?;
             let mut statefulset_spec = statefulset.spec.unwrap_or_default();
@@ -99,7 +99,7 @@ pub fn mutate_pod_spec_from_request<T: std::default::Default>(
             statefulset.spec = Some(statefulset_spec);
             mutate_request(serde_json::to_value(statefulset)?)
         }
-        DaemonSet::KIND => {
+        _ if is_resource::<DaemonSet>(gvk) => {
             let mut daemonset =
                 serde_json::from_value::<DaemonSet>(validation_request.request.object.clone())?;
             let mut daemonset_spec = daemonset.spec.unwrap_or_default();
@@ -107,7 +107,7 @@ pub fn mutate_pod_spec_from_request<T: std::default::Default>(
             daemonset.spec = Some(daemonset_spec);
             mutate_request(serde_json::to_value(daemonset)?)
         }
-        ReplicationController::KIND => {
+        _ if is_resource::<ReplicationController>(gvk) => {
             let mut replication_controller = serde_json::from_value::<ReplicationController>(
                 validation_request.request.object.clone(),
             )?;
@@ -118,7 +118,7 @@ pub fn mutate_pod_spec_from_request<T: std::default::Default>(
             replication_controller.spec = Some(replication_controller_spec);
             mutate_request(serde_json::to_value(replication_controller)?)
         }
-        CronJob::KIND => {
+        _ if is_resource::<CronJob>(gvk) => {
             let mut cronjob =
                 serde_json::from_value::<CronJob>(validation_request.request.object.clone())?;
             let mut cronjob_spec = cronjob.spec.unwrap_or_default();
@@ -132,21 +132,19 @@ pub fn mutate_pod_spec_from_request<T: std::default::Default>(
             cronjob.spec = Some(cronjob_spec);
             mutate_request(serde_json::to_value(cronjob)?)
         }
-        Job::KIND => {
+        _ if is_resource::<Job>(gvk) => {
             let mut job = serde_json::from_value::<Job>(validation_request.request.object.clone())?;
             let mut job_spec = job.spec.unwrap_or_default();
             job_spec.template.spec = Some(pod_spec);
             job.spec = Some(job_spec);
             mutate_request(serde_json::to_value(job)?)
         }
-        Pod::KIND => {
+        _ if is_resource::<Pod>(gvk) => {
             let mut pod = serde_json::from_value::<Pod>(validation_request.request.object.clone())?;
             pod.spec = Some(pod_spec);
             mutate_request(serde_json::to_value(pod)?)
         }
-        _ => {
-            reject_request(Some("Object should be one of these kinds: Deployment, ReplicaSet, StatefulSet, DaemonSet, ReplicationController, Job, CronJob, Pod".to_string()), None, None, None)
-        }
+        _ => reject_request(Some(supported_pod_spec_objects_message()), None, None, None),
     }
 }
 
@@ -356,17 +354,39 @@ mod tests {
 
     #[cfg(feature = "cluster-context")]
     fn create_validation_request<T: Serialize>(object: T, kind: &str) -> ValidationRequest<()> {
+        let (group, version) = group_version_for_kind(kind);
+        create_validation_request_with_gvk(object, group, version, kind)
+    }
+
+    #[cfg(feature = "cluster-context")]
+    fn create_validation_request_with_gvk<T: Serialize>(
+        object: T,
+        group: &str,
+        version: &str,
+        kind: &str,
+    ) -> ValidationRequest<()> {
         let value = serde_json::to_value(object).unwrap();
         ValidationRequest {
             settings: (),
             request: KubernetesAdmissionRequest {
                 kind: GroupVersionKind {
-                    kind: kind.to_string(),
-                    ..Default::default()
+                    group: group.to_owned(),
+                    version: version.to_owned(),
+                    kind: kind.to_owned(),
                 },
                 object: value,
                 ..Default::default()
             },
+        }
+    }
+
+    #[cfg(feature = "cluster-context")]
+    fn group_version_for_kind(kind: &str) -> (&'static str, &'static str) {
+        match kind {
+            "Deployment" | "ReplicaSet" | "StatefulSet" | "DaemonSet" => ("apps", "v1"),
+            "CronJob" | "Job" => ("batch", "v1"),
+            "ReplicationController" | "Pod" => ("", "v1"),
+            _ => ("", ""),
         }
     }
 
@@ -670,9 +690,44 @@ mod tests {
         let response: ValidationResponse = serde_json::from_slice(&raw_response.unwrap()).unwrap();
         assert!(!response.accepted);
         let error_message = response.message.unwrap_or_default();
-        let expected_error_message = "Object should be one of these kinds: Deployment, ReplicaSet, StatefulSet, DaemonSet, ReplicationController, Job, CronJob, Pod";
+        let expected_error_message = crate::request::supported_pod_spec_objects_message();
         assert_eq!(error_message, expected_error_message);
 
         Ok(())
+    }
+
+    #[cfg(feature = "cluster-context")]
+    #[test]
+    fn test_mutate_pod_spec_from_request_rejects_mismatched_group_version_kind() {
+        let deployment = Deployment {
+            spec: Some(DeploymentSpec {
+                template: PodTemplateSpec {
+                    spec: Some(PodSpec {
+                        automount_service_account_token: Some(false),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let validation_request =
+            create_validation_request_with_gvk(deployment, "argocd.io", "v1", "Deployment");
+
+        let new_pod_spec = PodSpec {
+            automount_service_account_token: Some(true),
+            ..Default::default()
+        };
+
+        let raw_response = mutate_pod_spec_from_request(validation_request, new_pod_spec);
+
+        assert!(raw_response.is_ok());
+        let response: ValidationResponse = serde_json::from_slice(&raw_response.unwrap()).unwrap();
+        assert!(!response.accepted);
+        assert_eq!(
+            response.message.unwrap_or_default(),
+            crate::request::supported_pod_spec_objects_message()
+        );
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -11,6 +11,33 @@ cfg_if::cfg_if! {
     }
 }
 
+#[cfg(feature = "cluster-context")]
+const SUPPORTED_POD_SPEC_OBJECTS: &str = concat!(
+    "apps/v1 Deployment, ",
+    "apps/v1 ReplicaSet, ",
+    "apps/v1 StatefulSet, ",
+    "apps/v1 DaemonSet, ",
+    "v1 ReplicationController, ",
+    "batch/v1 Job, ",
+    "batch/v1 CronJob, ",
+    "v1 Pod"
+);
+
+#[cfg(feature = "cluster-context")]
+pub(crate) fn supported_pod_spec_objects_message() -> String {
+    format!("Object should be one of these group/version/kinds: {SUPPORTED_POD_SPEC_OBJECTS}")
+}
+
+#[cfg(feature = "cluster-context")]
+pub(crate) fn supported_pod_spec_objects_error() -> String {
+    format!("object should be one of these group/version/kinds: {SUPPORTED_POD_SPEC_OBJECTS}")
+}
+
+#[cfg(feature = "cluster-context")]
+pub(crate) fn is_resource<T: Resource>(gvk: &GroupVersionKind) -> bool {
+    gvk.group == T::GROUP && gvk.version == T::VERSION && gvk.kind == T::KIND
+}
+
 /// ValidationRequest holds the data provided to the policy at evaluation time
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ValidationRequest<T: Default> {
@@ -165,53 +192,52 @@ where
     #[cfg(feature = "cluster-context")]
     /// Extract PodSpec from high level objects. This method can be used to evaluate high level objects instead of just Pods.
     /// For example, it can be used to reject Deployments or StatefulSets that violate a policy instead of the Pods created by them.
-    /// Objects supported are: Deployment, ReplicaSet, StatefulSet, DaemonSet, ReplicationController, Job, CronJob, Pod
+    /// Objects supported are: apps/v1 Deployment, apps/v1 ReplicaSet, apps/v1 StatefulSet, apps/v1 DaemonSet, v1 ReplicationController, batch/v1 Job, batch/v1 CronJob, v1 Pod
     /// It returns an error if the object is not one of those. If it is a supported object it returns the PodSpec if present, otherwise returns None.
     pub fn extract_pod_spec_from_object(&self) -> Result<Option<PodSpec>> {
-        match self.request.kind.kind.as_str() {
-            Deployment::KIND => {
+        let gvk = &self.request.kind;
+        match () {
+            _ if is_resource::<Deployment>(gvk) => {
                 let deployment = serde_json::from_value::<Deployment>(self.request.object.clone())?;
                 Ok(deployment.spec.and_then(|spec| spec.template.spec))
             }
-            ReplicaSet::KIND => {
+            _ if is_resource::<ReplicaSet>(gvk) => {
                 let replicaset = serde_json::from_value::<ReplicaSet>(self.request.object.clone())?;
                 Ok(replicaset
                     .spec
                     .and_then(|spec| spec.template.and_then(|template| template.spec)))
             }
-            StatefulSet::KIND => {
+            _ if is_resource::<StatefulSet>(gvk) => {
                 let statefulset =
                     serde_json::from_value::<StatefulSet>(self.request.object.clone())?;
                 Ok(statefulset.spec.and_then(|spec| spec.template.spec))
             }
-            DaemonSet::KIND => {
+            _ if is_resource::<DaemonSet>(gvk) => {
                 let daemonset = serde_json::from_value::<DaemonSet>(self.request.object.clone())?;
                 Ok(daemonset.spec.and_then(|spec| spec.template.spec))
             }
-            ReplicationController::KIND => {
+            _ if is_resource::<ReplicationController>(gvk) => {
                 let replication_controller =
                     serde_json::from_value::<ReplicationController>(self.request.object.clone())?;
                 Ok(replication_controller
                     .spec
                     .and_then(|spec| spec.template.and_then(|template| template.spec)))
             }
-            CronJob::KIND => {
+            _ if is_resource::<CronJob>(gvk) => {
                 let cronjob = serde_json::from_value::<CronJob>(self.request.object.clone())?;
                 Ok(cronjob
                     .spec
                     .and_then(|spec| spec.job_template.spec.and_then(|spec| spec.template.spec)))
             }
-            Job::KIND => {
+            _ if is_resource::<Job>(gvk) => {
                 let job = serde_json::from_value::<Job>(self.request.object.clone())?;
                 Ok(job.spec.and_then(|spec| spec.template.spec))
             }
-            Pod::KIND => {
+            _ if is_resource::<Pod>(gvk) => {
                 let pod = serde_json::from_value::<Pod>(self.request.object.clone())?;
                 Ok(pod.spec)
             }
-            _ => Err(Error::Validation(
-                "Object should be one of these kinds: Deployment, ReplicaSet, StatefulSet, DaemonSet, ReplicationController, Job, CronJob, Pod".to_string()
-            )),
+            _ => Err(Error::Validation(supported_pod_spec_objects_error())),
         }
     }
 }
@@ -440,18 +466,63 @@ mod tests {
         assert!(validation_request.extract_pod_spec_from_object().is_err())
     }
 
+    #[test]
+    fn test_extract_pod_spec_from_object_rejects_mismatched_group_version_kind() {
+        let deployment = Deployment {
+            spec: Some(DeploymentSpec {
+                template: PodTemplateSpec {
+                    spec: Some(PodSpec {
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let validation_request =
+            create_validation_request_with_gvk(deployment, "argocd.io", "v1", "Deployment");
+
+        let err = match validation_request.extract_pod_spec_from_object() {
+            Err(err) => err,
+            Ok(_) => panic!("expected mismatched group/version/kind error"),
+        };
+
+        assert_eq!(err.to_string(), supported_pod_spec_objects_error())
+    }
+
     fn create_validation_request<T: Serialize>(object: T, kind: &str) -> ValidationRequest<()> {
+        let (group, version) = group_version_for_kind(kind);
+        create_validation_request_with_gvk(object, group, version, kind)
+    }
+
+    fn create_validation_request_with_gvk<T: Serialize>(
+        object: T,
+        group: &str,
+        version: &str,
+        kind: &str,
+    ) -> ValidationRequest<()> {
         let value = serde_json::to_value(object).unwrap();
         ValidationRequest {
             settings: (),
             request: KubernetesAdmissionRequest {
                 kind: GroupVersionKind {
-                    kind: kind.to_string(),
-                    ..Default::default()
+                    group: group.to_owned(),
+                    version: version.to_owned(),
+                    kind: kind.to_owned(),
                 },
                 object: value,
                 ..Default::default()
             },
+        }
+    }
+
+    fn group_version_for_kind(kind: &str) -> (&'static str, &'static str) {
+        match kind {
+            "Deployment" | "ReplicaSet" | "StatefulSet" | "DaemonSet" => ("apps", "v1"),
+            "CronJob" | "Job" => ("batch", "v1"),
+            "ReplicationController" | "Pod" | "ConfigMap" => ("", "v1"),
+            _ => ("", ""),
         }
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -29,13 +29,49 @@ pub(crate) fn supported_pod_spec_objects_message() -> String {
 }
 
 #[cfg(feature = "cluster-context")]
-pub(crate) fn supported_pod_spec_objects_error() -> String {
-    format!("object should be one of these group/version/kinds: {SUPPORTED_POD_SPEC_OBJECTS}")
-}
-
-#[cfg(feature = "cluster-context")]
 pub(crate) fn is_resource<T: Resource>(gvk: &GroupVersionKind) -> bool {
     gvk.group == T::GROUP && gvk.version == T::VERSION && gvk.kind == T::KIND
+}
+
+#[cfg(all(test, feature = "cluster-context"))]
+pub(crate) fn create_validation_request<T: Serialize>(
+    object: T,
+    kind: &str,
+) -> ValidationRequest<()> {
+    let (group, version) = group_version_for_kind(kind);
+    create_validation_request_with_gvk(object, group, version, kind)
+}
+
+#[cfg(all(test, feature = "cluster-context"))]
+pub(crate) fn create_validation_request_with_gvk<T: Serialize>(
+    object: T,
+    group: &str,
+    version: &str,
+    kind: &str,
+) -> ValidationRequest<()> {
+    let value = serde_json::to_value(object).unwrap();
+    ValidationRequest {
+        settings: (),
+        request: KubernetesAdmissionRequest {
+            kind: GroupVersionKind {
+                group: group.to_owned(),
+                version: version.to_owned(),
+                kind: kind.to_owned(),
+            },
+            object: value,
+            ..Default::default()
+        },
+    }
+}
+
+#[cfg(all(test, feature = "cluster-context"))]
+fn group_version_for_kind(kind: &str) -> (&'static str, &'static str) {
+    match kind {
+        "Deployment" | "ReplicaSet" | "StatefulSet" | "DaemonSet" => ("apps", "v1"),
+        "CronJob" | "Job" => ("batch", "v1"),
+        "ReplicationController" | "Pod" | "ConfigMap" => ("", "v1"),
+        _ => ("", ""),
+    }
 }
 
 /// ValidationRequest holds the data provided to the policy at evaluation time
@@ -196,48 +232,39 @@ where
     /// It returns an error if the object is not one of those. If it is a supported object it returns the PodSpec if present, otherwise returns None.
     pub fn extract_pod_spec_from_object(&self) -> Result<Option<PodSpec>> {
         let gvk = &self.request.kind;
-        match () {
-            _ if is_resource::<Deployment>(gvk) => {
-                let deployment = serde_json::from_value::<Deployment>(self.request.object.clone())?;
-                Ok(deployment.spec.and_then(|spec| spec.template.spec))
-            }
-            _ if is_resource::<ReplicaSet>(gvk) => {
-                let replicaset = serde_json::from_value::<ReplicaSet>(self.request.object.clone())?;
-                Ok(replicaset
-                    .spec
-                    .and_then(|spec| spec.template.and_then(|template| template.spec)))
-            }
-            _ if is_resource::<StatefulSet>(gvk) => {
-                let statefulset =
-                    serde_json::from_value::<StatefulSet>(self.request.object.clone())?;
-                Ok(statefulset.spec.and_then(|spec| spec.template.spec))
-            }
-            _ if is_resource::<DaemonSet>(gvk) => {
-                let daemonset = serde_json::from_value::<DaemonSet>(self.request.object.clone())?;
-                Ok(daemonset.spec.and_then(|spec| spec.template.spec))
-            }
-            _ if is_resource::<ReplicationController>(gvk) => {
-                let replication_controller =
-                    serde_json::from_value::<ReplicationController>(self.request.object.clone())?;
-                Ok(replication_controller
-                    .spec
-                    .and_then(|spec| spec.template.and_then(|template| template.spec)))
-            }
-            _ if is_resource::<CronJob>(gvk) => {
-                let cronjob = serde_json::from_value::<CronJob>(self.request.object.clone())?;
-                Ok(cronjob
-                    .spec
-                    .and_then(|spec| spec.job_template.spec.and_then(|spec| spec.template.spec)))
-            }
-            _ if is_resource::<Job>(gvk) => {
-                let job = serde_json::from_value::<Job>(self.request.object.clone())?;
-                Ok(job.spec.and_then(|spec| spec.template.spec))
-            }
-            _ if is_resource::<Pod>(gvk) => {
-                let pod = serde_json::from_value::<Pod>(self.request.object.clone())?;
-                Ok(pod.spec)
-            }
-            _ => Err(Error::Validation(supported_pod_spec_objects_error())),
+        if is_resource::<Deployment>(gvk) {
+            let deployment = serde_json::from_value::<Deployment>(self.request.object.clone())?;
+            Ok(deployment.spec.and_then(|spec| spec.template.spec))
+        } else if is_resource::<ReplicaSet>(gvk) {
+            let replicaset = serde_json::from_value::<ReplicaSet>(self.request.object.clone())?;
+            Ok(replicaset
+                .spec
+                .and_then(|spec| spec.template.and_then(|template| template.spec)))
+        } else if is_resource::<StatefulSet>(gvk) {
+            let statefulset = serde_json::from_value::<StatefulSet>(self.request.object.clone())?;
+            Ok(statefulset.spec.and_then(|spec| spec.template.spec))
+        } else if is_resource::<DaemonSet>(gvk) {
+            let daemonset = serde_json::from_value::<DaemonSet>(self.request.object.clone())?;
+            Ok(daemonset.spec.and_then(|spec| spec.template.spec))
+        } else if is_resource::<ReplicationController>(gvk) {
+            let replication_controller =
+                serde_json::from_value::<ReplicationController>(self.request.object.clone())?;
+            Ok(replication_controller
+                .spec
+                .and_then(|spec| spec.template.and_then(|template| template.spec)))
+        } else if is_resource::<CronJob>(gvk) {
+            let cronjob = serde_json::from_value::<CronJob>(self.request.object.clone())?;
+            Ok(cronjob
+                .spec
+                .and_then(|spec| spec.job_template.spec.and_then(|spec| spec.template.spec)))
+        } else if is_resource::<Job>(gvk) {
+            let job = serde_json::from_value::<Job>(self.request.object.clone())?;
+            Ok(job.spec.and_then(|spec| spec.template.spec))
+        } else if is_resource::<Pod>(gvk) {
+            let pod = serde_json::from_value::<Pod>(self.request.object.clone())?;
+            Ok(pod.spec)
+        } else {
+            Err(Error::Validation(supported_pod_spec_objects_message()))
         }
     }
 }
@@ -251,8 +278,6 @@ mod tests {
     };
     use k8s_openapi::api::batch::v1::{CronJobSpec, JobSpec, JobTemplateSpec};
     use k8s_openapi::api::core::v1::{ConfigMap, PodTemplateSpec};
-
-    use serde::Serialize;
 
     #[test]
     fn test_extract_pod_spec_from_deployment() {
@@ -488,41 +513,6 @@ mod tests {
             Ok(_) => panic!("expected mismatched group/version/kind error"),
         };
 
-        assert_eq!(err.to_string(), supported_pod_spec_objects_error())
-    }
-
-    fn create_validation_request<T: Serialize>(object: T, kind: &str) -> ValidationRequest<()> {
-        let (group, version) = group_version_for_kind(kind);
-        create_validation_request_with_gvk(object, group, version, kind)
-    }
-
-    fn create_validation_request_with_gvk<T: Serialize>(
-        object: T,
-        group: &str,
-        version: &str,
-        kind: &str,
-    ) -> ValidationRequest<()> {
-        let value = serde_json::to_value(object).unwrap();
-        ValidationRequest {
-            settings: (),
-            request: KubernetesAdmissionRequest {
-                kind: GroupVersionKind {
-                    group: group.to_owned(),
-                    version: version.to_owned(),
-                    kind: kind.to_owned(),
-                },
-                object: value,
-                ..Default::default()
-            },
-        }
-    }
-
-    fn group_version_for_kind(kind: &str) -> (&'static str, &'static str) {
-        match kind {
-            "Deployment" | "ReplicaSet" | "StatefulSet" | "DaemonSet" => ("apps", "v1"),
-            "CronJob" | "Job" => ("batch", "v1"),
-            "ReplicationController" | "Pod" | "ConfigMap" => ("", "v1"),
-            _ => ("", ""),
-        }
+        assert_eq!(err.to_string(), supported_pod_spec_objects_message())
     }
 }


### PR DESCRIPTION
## Summary
- match PodSpec-bearing resources by full group/version/kind instead of kind only
- share the supported-resource message between extract and mutate paths
- add regressions for argocd.io/v1 Deployment being rejected

Fixes #126

## Testing
- git diff --check
- docker run --rm --user "$(id -u):$(id -g)" -e CARGO_HOME=/tmp/cargo -v "$PWD":/work -w /work rust:1-bookworm cargo test