### PR TITLE
ci: proc-macro-error2 is no longer maintained, update cargo deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -70,10 +70,7 @@ feature-depth = 1
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-  #"RUSTSEC-0000-0000",
-  #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
-  #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
-  #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
+  { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is no longer maintained. This is a dependency of oci-spec crate" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
proc-macro-error2 is no longer maintained. This is a dependency of oci-spec crate.

Update cargo deny configuration to ignore that until a solution is found by oci-spec.
