### PR TITLE
chore: prepare for 0.17.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2024"
 license = "Apache-2.0"
 name = "kubewarden-policy-sdk"
 repository = "https://github.com/kubewarden/policy-sdk-rust"
-version = "0.17.1"
+version = "0.17.2"
 
 [features]
 cluster-context = ["k8s-openapi"]


### PR DESCRIPTION
This release is done to consume new dependencies, like k8s-openapi
